### PR TITLE
add extra properties to error objects

### DIFF
--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -105,8 +105,13 @@ declare module "single-spa" {
   export function triggerAppChange(): Promise<any>;
 
   // './applications/app-errors.js'
-  export function addErrorHandler(handler: (error: Error) => void): void;
-  export function removeErrorHandler(handler: (error: Error) => void): void;
+  type AppError = Error & {
+    appOrParcelName: string;
+    message: string;
+  }
+  export function addErrorHandler(handler: (error: AppError) => void): void;
+  export function removeErrorHandler(handler: (error: AppError) => void): void;
+
 
   // './parcels/mount-parcel.js'
   export function mountRootParcel(parcelConfig: ParcelConfig, parcelProps: object): Parcel;

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -107,7 +107,6 @@ declare module "single-spa" {
   // './applications/app-errors.js'
   type AppError = Error & {
     appOrParcelName: string;
-    message: string;
   }
   export function addErrorHandler(handler: (error: AppError) => void): void;
   export function removeErrorHandler(handler: (error: AppError) => void): void;


### PR DESCRIPTION
From the docs [here](https://single-spa.js.org/docs/api#adderrorhandler):

errorHandler: Function(error: Error)
Must be a function. Will be called with an Error object that additionally has a `message` and `appOrParcelName` property.

Added these two extra properties to typings.d.ts