### PR TITLE
bugfix: catch the error while call the captured event listeners

### DIFF
--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -64,17 +64,17 @@ export function callCapturedEventListeners(eventArguments) {
   if (eventArguments) {
     const eventType = eventArguments[0].type;
     if (routingEventsListeningTo.indexOf(eventType) >= 0) {
-      // The error thrown by application event listener should not break single-spa down.
-      // Just like https://github.com/single-spa/single-spa/blob/85f5042dff960e40936f3a5069d56fc9477fac04/src/navigation/reroute.js#L140-L146 did
-      try {
-        capturedEventListeners[eventType].forEach(listener => {
+      capturedEventListeners[eventType].forEach(listener => {
+        try {
+          // The error thrown by application event listener should not break single-spa down.
+          // Just like https://github.com/single-spa/single-spa/blob/85f5042dff960e40936f3a5069d56fc9477fac04/src/navigation/reroute.js#L140-L146 did
           listener.apply(this, eventArguments);
-        });
-      } catch (e) {
-        setTimeout(() => {
-          throw e;
-        });
-      }
+        } catch (e) {
+          setTimeout(() => {
+            throw e;
+          });
+        }
+      });
     }
   }
 }

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -64,9 +64,17 @@ export function callCapturedEventListeners(eventArguments) {
   if (eventArguments) {
     const eventType = eventArguments[0].type;
     if (routingEventsListeningTo.indexOf(eventType) >= 0) {
-      capturedEventListeners[eventType].forEach(listener => {
-        listener.apply(this, eventArguments);
-      });
+      // The error thrown by application event listener should not break single-spa down.
+      // Just like https://github.com/single-spa/single-spa/blob/85f5042dff960e40936f3a5069d56fc9477fac04/src/navigation/reroute.js#L140-L146 did
+      try {
+        capturedEventListeners[eventType].forEach(listener => {
+          listener.apply(this, eventArguments);
+        });
+      } catch (e) {
+        setTimeout(() => {
+          throw e;
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
single-spa should catch the error which thrown by the sub app url change event handler, just like https://github.com/single-spa/single-spa/blob/master/src/navigation/reroute.js#L140 did.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/single-spa/single-spa/449)
<!-- Reviewable:end -->
