### PR TITLE
Fix: error handler now called after app status is updated. Resolves #466

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,12 +21,8 @@ const terserOpts = {
   compress: {
     passes: 2
   },
-  mangle: {
-    safari10: true
-  },
   module: true,
   output: {
-    safari10: true,
     comments(node, comment) {
       return comment.value.trim().startsWith("single-spa@");
     }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,8 +21,12 @@ const terserOpts = {
   compress: {
     passes: 2
   },
+  mangle: {
+    safari10: true
+  },
   module: true,
   output: {
+    safari10: true,
     comments(node, comment) {
       return comment.value.trim().startsWith("single-spa@");
     }

--- a/spec/apis/error-handlers.spec.js
+++ b/spec/apis/error-handlers.spec.js
@@ -32,11 +32,9 @@ describe("error handlers api", () => {
     return singleSpa.triggerAppChange().then(() => {
       expect(errs.length).toBe(1);
       expect(errs[0].appOrParcelName).toBe("load-error");
-      expect(
-        errs[0].message.indexOf(
-          `'load-error' died in status LOADING_SOURCE_CODE: "Could not load this one"`
-        )
-      ).toBeGreaterThan(-1);
+      expect(errs[0].message).toMatch(
+        `'load-error' died in status LOAD_ERROR: "Could not load this one"`
+      );
     });
   });
 

--- a/spec/apis/error-handlers.spec.js
+++ b/spec/apis/error-handlers.spec.js
@@ -33,8 +33,9 @@ describe("error handlers api", () => {
       expect(errs.length).toBe(1);
       expect(errs[0].appOrParcelName).toBe("load-error");
       expect(errs[0].message).toMatch(
-        `'load-error' died in status LOAD_ERROR: "Could not load this one"`
+        `'load-error' died in status LOADING_SOURCE_CODE: "Could not load this one"`
       );
+      expect(singleSpa.getAppStatus("load-error")).toBe(singleSpa.LOAD_ERROR);
     });
   });
 
@@ -62,11 +63,9 @@ describe("error handlers api", () => {
     return singleSpa.triggerAppChange().then(() => {
       expect(errs.length).toBe(1);
       expect(errs[0].appOrParcelName).toBe("bootstrap-error");
-      expect(
-        errs[0].message.indexOf(
-          `'bootstrap-error' died in status SKIP_BECAUSE_BROKEN: couldn't bootstrap`
-        )
-      ).toBeGreaterThan(-1);
+      expect(errs[0].message).toMatch(
+        `'bootstrap-error' died in status BOOTSTRAPPING: couldn't bootstrap`
+      );
     });
   });
 

--- a/spec/apis/error-handlers.spec.js
+++ b/spec/apis/error-handlers.spec.js
@@ -66,6 +66,9 @@ describe("error handlers api", () => {
       expect(errs[0].message).toMatch(
         `'bootstrap-error' died in status BOOTSTRAPPING: couldn't bootstrap`
       );
+      expect(singleSpa.getAppStatus("bootstrap-error")).toBe(
+        singleSpa.SKIP_BECAUSE_BROKEN
+      );
     });
   });
 

--- a/spec/apps/load-error/load-error.spec.js
+++ b/spec/apps/load-error/load-error.spec.js
@@ -1,0 +1,37 @@
+import * as singleSpa from "single-spa";
+
+describe(`load-error`, () => {
+  it(`will mount an application before loading another application finishes`, async () => {
+    singleSpa.registerApplication(
+      "load-error",
+      () => Promise.reject(Error(`load failed`)),
+      location => location.hash.startsWith("#load-error")
+    );
+    location.hash = "#load-error";
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.getAppStatus("load-error")).toBe(singleSpa.LOAD_ERROR);
+  });
+
+  it(`puts app into LOAD_ERROR status before firing error event`, async () => {
+    let numErrs = 0;
+
+    await singleSpa.triggerAppChange();
+    singleSpa.addErrorHandler(handleError);
+
+    singleSpa.registerApplication(
+      "load-error-2",
+      () => Promise.reject(Error(`load failed`)),
+      location => location.hash.startsWith("#load-error-2")
+    );
+    location.hash = "#load-error-2";
+    await singleSpa.triggerAppChange();
+    singleSpa.removeErrorHandler(handleError);
+    expect(numErrs).toBe(1);
+
+    function handleError(evt) {
+      numErrs++;
+      const appName = evt.appOrParcelName;
+      expect(singleSpa.getAppStatus(appName)).toBe(singleSpa.LOAD_ERROR);
+    }
+  });
+});

--- a/spec/parcels/parcel-error-handlers.spec.js
+++ b/spec/parcels/parcel-error-handlers.spec.js
@@ -24,19 +24,12 @@ describe("parcel errors", () => {
           const parcel1 = app.mountProps.mountParcel(parcelConfig1, {
             domElement: document.createElement("div")
           });
-          return parcel1.bootstrapPromise
-            .catch(err => {
-              expect(err.appOrParcelName).toBe("bootstrap-error");
-              expect(
-                err.message.indexOf(`SKIP_BECAUSE_BROKEN`)
-              ).toBeGreaterThan(-1);
-              expect(err.message.indexOf(`bootstrap-error`)).toBeGreaterThan(
-                -1
-              );
-            })
-            .then(() => {
-              expect(parcel1.getStatus()).toBe("SKIP_BECAUSE_BROKEN");
-            });
+          return parcel1.bootstrapPromise.catch(err => {
+            expect(err.appOrParcelName).toBe("bootstrap-error");
+            expect(err.message).toMatch(`BOOTSTRAPPING`);
+            expect(err.message.indexOf(`bootstrap-error`)).toBeGreaterThan(-1);
+            expect(parcel1.getStatus()).toBe("SKIP_BECAUSE_BROKEN");
+          });
         });
       });
     });
@@ -62,7 +55,7 @@ describe("parcel errors", () => {
           return parcel1.mountPromise
             .catch(err => {
               expect(err.appOrParcelName).toBe("mount-error");
-              expect(err.message.indexOf(`NOT_MOUNTED`)).toBeGreaterThan(-1);
+              expect(err.message).toMatch("NOT_MOUNTED");
             })
             .then(() => {
               expect(parcel1.getStatus()).toBe("SKIP_BECAUSE_BROKEN");

--- a/spec/parcels/parcel-error-handlers.spec.js
+++ b/spec/parcels/parcel-error-handlers.spec.js
@@ -52,14 +52,11 @@ describe("parcel errors", () => {
           const parcel1 = app.mountProps.mountParcel(parcelConfig1, {
             domElement: document.createElement("div")
           });
-          return parcel1.mountPromise
-            .catch(err => {
-              expect(err.appOrParcelName).toBe("mount-error");
-              expect(err.message).toMatch("NOT_MOUNTED");
-            })
-            .then(() => {
-              expect(parcel1.getStatus()).toBe("SKIP_BECAUSE_BROKEN");
-            });
+          return parcel1.mountPromise.catch(err => {
+            expect(err.appOrParcelName).toBe("mount-error");
+            expect(err.message).toMatch("NOT_MOUNTED");
+            expect(parcel1.getStatus()).toBe(singleSpa.SKIP_BECAUSE_BROKEN);
+          });
         });
       });
     });

--- a/src/applications/app-errors.js
+++ b/src/applications/app-errors.js
@@ -2,8 +2,12 @@ import { objectType, toName } from "./app.helpers";
 
 let errorHandlers = [];
 
-export function handleAppError(err, app) {
+export function handleAppError(err, app, newStatus) {
   const transformedErr = transformErr(err, app);
+
+  // We set the status after transforming the error so that the error message
+  // references the state the application was in before the status change.
+  app.status = newStatus;
 
   if (errorHandlers.length) {
     errorHandlers.forEach(handler => handler(transformedErr));

--- a/src/applications/app-errors.js
+++ b/src/applications/app-errors.js
@@ -3,11 +3,7 @@ import { objectType, toName } from "./app.helpers";
 let errorHandlers = [];
 
 export function handleAppError(err, app, newStatus) {
-  const transformedErr = transformErr(err, app);
-
-  // We set the status after transforming the error so that the error message
-  // references the state the application was in before the status change.
-  app.status = newStatus;
+  const transformedErr = transformErr(err, app, newStatus);
 
   if (errorHandlers.length) {
     errorHandlers.forEach(handler => handler(transformedErr));
@@ -59,7 +55,7 @@ export function formatErrorMessage(code, msg, ...args) {
   }`;
 }
 
-export function transformErr(ogErr, appOrParcel) {
+export function transformErr(ogErr, appOrParcel, newStatus) {
   const errPrefix = `${objectType(appOrParcel)} '${toName(
     appOrParcel
   )}' died in status ${appOrParcel.status}: `;
@@ -96,6 +92,10 @@ export function transformErr(ogErr, appOrParcel) {
   }
 
   result.appOrParcelName = toName(appOrParcel);
+
+  // We set the status after transforming the error so that the error message
+  // references the state the application was in before the status change.
+  appOrParcel.status = newStatus;
 
   return result;
 }

--- a/src/applications/app.helpers.js
+++ b/src/applications/app.helpers.js
@@ -38,8 +38,7 @@ export function shouldBeActive(app) {
   try {
     return app.activeWhen(window.location);
   } catch (err) {
-    handleAppError(err, app);
-    app.status = SKIP_BECAUSE_BROKEN;
+    handleAppError(err, app, SKIP_BECAUSE_BROKEN);
   }
 }
 
@@ -47,8 +46,7 @@ export function shouldntBeActive(app) {
   try {
     return !app.activeWhen(window.location);
   } catch (err) {
-    handleAppError(err, app);
-    app.status = SKIP_BECAUSE_BROKEN;
+    handleAppError(err, app, SKIP_BECAUSE_BROKEN);
   }
 }
 

--- a/src/lifecycles/bootstrap.js
+++ b/src/lifecycles/bootstrap.js
@@ -22,9 +22,7 @@ export function toBootstrapPromise(appOrParcel, hardFail) {
       })
       .catch(err => {
         if (hardFail) {
-          const transformedErr = transformErr(err, appOrParcel);
-          appOrParcel.status = SKIP_BECAUSE_BROKEN;
-          throw transformedErr;
+          throw transformErr(err, appOrParcel, SKIP_BECAUSE_BROKEN);
         } else {
           handleAppError(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           return appOrParcel;

--- a/src/lifecycles/bootstrap.js
+++ b/src/lifecycles/bootstrap.js
@@ -21,11 +21,12 @@ export function toBootstrapPromise(appOrParcel, hardFail) {
         return appOrParcel;
       })
       .catch(err => {
-        appOrParcel.status = SKIP_BECAUSE_BROKEN;
         if (hardFail) {
-          throw transformErr(err, appOrParcel);
+          const transformedErr = transformErr(err, appOrParcel);
+          appOrParcel.status = SKIP_BECAUSE_BROKEN;
+          throw transformedErr;
         } else {
-          handleAppError(err, appOrParcel);
+          handleAppError(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           return appOrParcel;
         }
       });

--- a/src/lifecycles/load.js
+++ b/src/lifecycles/load.js
@@ -134,13 +134,13 @@ export function toLoadPromise(app) {
       .catch(err => {
         delete app.loadPromise;
 
-        handleAppError(err, app);
         if (isUserErr) {
           app.status = SKIP_BECAUSE_BROKEN;
         } else {
           app.status = LOAD_ERROR;
           app.loadErrorTime = new Date().getTime();
         }
+        handleAppError(err, app);
 
         return app;
       }));

--- a/src/lifecycles/load.js
+++ b/src/lifecycles/load.js
@@ -106,8 +106,7 @@ export function toLoadPromise(app) {
               ),
               appOpts
             );
-            handleAppError(validationErrMessage, app);
-            app.status = SKIP_BECAUSE_BROKEN;
+            handleAppError(validationErrMessage, app, SKIP_BECAUSE_BROKEN);
             return app;
           }
 
@@ -134,13 +133,14 @@ export function toLoadPromise(app) {
       .catch(err => {
         delete app.loadPromise;
 
+        let newStatus;
         if (isUserErr) {
-          app.status = SKIP_BECAUSE_BROKEN;
+          newStatus = SKIP_BECAUSE_BROKEN;
         } else {
-          app.status = LOAD_ERROR;
+          newStatus = LOAD_ERROR;
           app.loadErrorTime = new Date().getTime();
         }
-        handleAppError(err, app);
+        handleAppError(err, app, newStatus);
 
         return app;
       }));

--- a/src/lifecycles/mount.js
+++ b/src/lifecycles/mount.js
@@ -45,8 +45,7 @@ export function toMountPromise(appOrParcel, hardFail) {
 
         function setSkipBecauseBroken() {
           if (!hardFail) {
-            handleAppError(err, appOrParcel);
-            appOrParcel.status = SKIP_BECAUSE_BROKEN;
+            handleAppError(err, appOrParcel, SKIP_BECAUSE_BROKEN);
             return appOrParcel;
           } else {
             const transformedErr = transformErr(err, appOrParcel);

--- a/src/lifecycles/mount.js
+++ b/src/lifecycles/mount.js
@@ -48,9 +48,7 @@ export function toMountPromise(appOrParcel, hardFail) {
             handleAppError(err, appOrParcel, SKIP_BECAUSE_BROKEN);
             return appOrParcel;
           } else {
-            const transformedErr = transformErr(err, appOrParcel);
-            appOrParcel.status = SKIP_BECAUSE_BROKEN;
-            throw transformedErr;
+            throw transformErr(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           }
         }
       });

--- a/src/lifecycles/unload.js
+++ b/src/lifecycles/unload.js
@@ -81,8 +81,7 @@ function errorUnloadingApp(app, unloadInfo, err) {
   delete app.unmount;
   delete app.unload;
 
-  handleAppError(err, app);
-  app.status = SKIP_BECAUSE_BROKEN;
+  handleAppError(err, app, SKIP_BECAUSE_BROKEN);
   unloadInfo.reject(err);
 }
 

--- a/src/lifecycles/unmount.js
+++ b/src/lifecycles/unmount.js
@@ -31,8 +31,7 @@ export function toUnmountPromise(appOrParcel, hardFail) {
             appOrParcel.status = SKIP_BECAUSE_BROKEN;
             throw transformedErr;
           } else {
-            handleAppError(parentError, appOrParcel);
-            appOrParcel.status = SKIP_BECAUSE_BROKEN;
+            handleAppError(parentError, appOrParcel, SKIP_BECAUSE_BROKEN);
           }
         });
       })
@@ -50,11 +49,9 @@ export function toUnmountPromise(appOrParcel, hardFail) {
         .catch(err => {
           if (hardFail) {
             const transformedErr = transformErr(err, appOrParcel);
-            appOrParcel.status = SKIP_BECAUSE_BROKEN;
             throw transformedErr;
           } else {
-            handleAppError(err, appOrParcel);
-            appOrParcel.status = SKIP_BECAUSE_BROKEN;
+            handleAppError(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           }
         });
     }

--- a/src/lifecycles/unmount.js
+++ b/src/lifecycles/unmount.js
@@ -27,9 +27,7 @@ export function toUnmountPromise(appOrParcel, hardFail) {
           // Unmounting the app/parcel succeeded, but unmounting its children parcels did not
           const parentError = Error(parcelError.message);
           if (hardFail) {
-            const transformedErr = transformErr(parentError, appOrParcel);
-            appOrParcel.status = SKIP_BECAUSE_BROKEN;
-            throw transformedErr;
+            throw transformErr(parentError, appOrParcel, SKIP_BECAUSE_BROKEN);
           } else {
             handleAppError(parentError, appOrParcel, SKIP_BECAUSE_BROKEN);
           }
@@ -48,8 +46,7 @@ export function toUnmountPromise(appOrParcel, hardFail) {
         })
         .catch(err => {
           if (hardFail) {
-            const transformedErr = transformErr(err, appOrParcel);
-            throw transformedErr;
+            throw transformErr(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           } else {
             handleAppError(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           }

--- a/src/lifecycles/update.js
+++ b/src/lifecycles/update.js
@@ -33,9 +33,7 @@ export function toUpdatePromise(parcel) {
         return parcel;
       })
       .catch(err => {
-        const transformedErr = transformErr(err, parcel);
-        parcel.status = SKIP_BECAUSE_BROKEN;
-        throw transformedErr;
+        throw transformErr(err, parcel, SKIP_BECAUSE_BROKEN);
       });
   });
 }


### PR DESCRIPTION
See #466. We were sometimes calling the error handler before updating the application/parcel status, and sometimes not.

The desired behavior that I settled on in this PR: the `error.message` given to error handlers has the status of the application/parcel from **before the error** ("While UNMOUNTING, ...."). But the status itself should be set to either SKIP_BECAUSE_BROKEN or LOAD_ERROR before the error handler is called.

I was impressed with our test coverage on this - we have lots of tests verifying error messages and statuses. I had to update a few of them to this new behavior, but believe the changes are good ones and also are things that probably no one will be counting on in their code. I don't consider this to be a breaking change.

Also coincidentally this PR lowers the bundle size of single-spa by about 100 bytes, bringing it closer to my arbitrary goal of a <15kb ungzipped ESM single-spa build