### PR TITLE
Not throwing error when unmount fails after a failed mount.

### DIFF
--- a/spec/apis/error-handlers.spec.js
+++ b/spec/apis/error-handlers.spec.js
@@ -171,4 +171,27 @@ describe("error handlers api", () => {
       ).toBeGreaterThan(-1);
     });
   });
+
+  it(`only throws one error when the application or parcel fails to mount`, async () => {
+    const app = {
+      async bootstrap() {},
+      async mount() {
+        throw Error("the mount failed");
+      },
+      async unmount() {
+        throw Error("the unmount failed");
+      }
+    };
+    location.hash = "#";
+    await singleSpa.triggerAppChange();
+    singleSpa.registerApplication("one-error-only", app, location =>
+      location.hash.startsWith("#one-error-only")
+    );
+    location.hash = "#one-error-only";
+    await singleSpa.triggerAppChange();
+
+    expect(errs.length).toBe(1);
+    expect(errs[0].message).toMatch("the mount failed");
+    expect(errs[0].message).not.toMatch("the unmount");
+  });
 });

--- a/src/lifecycles/mount.js
+++ b/src/lifecycles/mount.js
@@ -38,7 +38,7 @@ export function toMountPromise(appOrParcel, hardFail) {
         // We temporarily put the appOrParcel into MOUNTED status so that toUnmountPromise actually attempts to unmount it
         // instead of just doing a no-op.
         appOrParcel.status = MOUNTED;
-        return toUnmountPromise(appOrParcel).then(
+        return toUnmountPromise(appOrParcel, true).then(
           setSkipBecauseBroken,
           setSkipBecauseBroken
         );


### PR DESCRIPTION
There have been several issues and questions where people are getting confused that their application is failing to unmount even though the root cause is that the application is failing to mount and then the auto-unmount after mount is also failing. For example, see https://github.com/single-spa/single-spa/issues/478 and https://github.com/single-spa/single-spa-svelte/issues/8

This fixes it by changing the `hardFail` argument for `toUnmountPromise` to be `true` so that the error isn't automatically reported inside of toUnmoutPromise. Then we ignore the unmount error inside of toMountPromise, preferring to only throw the mount error instead of both the mount and unmount errors.