### PR TITLE
Support for running single-spa in nodejs.

### DIFF
--- a/jest-browser.config.js
+++ b/jest-browser.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: "jsdom",
+  moduleNameMapper: {
+    "single-spa": "<rootDir>/src/single-spa.js"
+  },
+  setupFiles: ["<rootDir>/spec/test-setup.js"]
+};

--- a/jest-node.config.js
+++ b/jest-node.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "single-spa": "<rootDir>/src/single-spa.js"
+  },
+  testRegex: "node-spec/.+.(spec|test).js"
+};

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,0 @@
-{
-  "moduleNameMapper": {
-    "single-spa": "<rootDir>/src/single-spa.js"
-  },
-  "setupFiles": ["<rootDir>/spec/test-setup.js"]
-}

--- a/node-spec/nodejs.spec.js
+++ b/node-spec/nodejs.spec.js
@@ -31,5 +31,9 @@ describe(`nodejs spec`, () => {
         "navbar"
       ]);
     });
+
+    it("doesn't die if you call singleSpa.start()", () => {
+      singleSpa.start();
+    });
   });
 });

--- a/node-spec/nodejs.spec.js
+++ b/node-spec/nodejs.spec.js
@@ -5,6 +5,9 @@ describe(`nodejs spec`, () => {
     it("can still check activity functions in nodejs with a mocked Location object", () => {
       singleSpa.registerApplication(
         "app1",
+        /* Note that on the server, System is likely undefined. But this is okay and doesn't cause problems
+         * because single-spa doesn't call the loading functions when checking activity functions
+         */
         () => System.import("app1"),
         location => location.pathname.startsWith("/app1")
       );

--- a/node-spec/nodejs.spec.js
+++ b/node-spec/nodejs.spec.js
@@ -1,4 +1,4 @@
-import * as singleSpa from "single-spa";
+const singleSpa = require("single-spa");
 
 describe(`nodejs spec`, () => {
   describe("activity functions", () => {

--- a/node-spec/nodejs.spec.js
+++ b/node-spec/nodejs.spec.js
@@ -1,0 +1,35 @@
+import * as singleSpa from "single-spa";
+
+describe(`nodejs spec`, () => {
+  describe("activity functions", () => {
+    it("can still check activity functions in nodejs with a mocked Location object", () => {
+      singleSpa.registerApplication(
+        "app1",
+        () => System.import("app1"),
+        location => location.pathname.startsWith("/app1")
+      );
+      singleSpa.registerApplication(
+        "app2",
+        () => System.import("app2"),
+        location => location.pathname.startsWith("/app2")
+      );
+      singleSpa.registerApplication(
+        "navbar",
+        () => System.import("navbar"),
+        location => true
+      );
+
+      expect(singleSpa.checkActivityFunctions({ pathname: "/app1" })).toEqual([
+        "app1",
+        "navbar"
+      ]);
+      expect(singleSpa.checkActivityFunctions({ pathname: "/app2" })).toEqual([
+        "app2",
+        "navbar"
+      ]);
+      expect(singleSpa.checkActivityFunctions({ pathname: "/app3" })).toEqual([
+        "navbar"
+      ]);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "watch": "rollup -c -w",
     "prepublishOnly": "yarn build",
     "clean": "rimraf lib",
-    "test": "cross-env BABEL_ENV=test jest --config jest.config.json",
+    "test": "concurrently -n w: 'yarn:test:*'",
+    "test:browser": "cross-env BABEL_ENV=test jest --config jest-browser.config.js",
+    "test:node": "cross-env BABEL_ENV=test jest --config jest-node.config.js",
     "prettier": "prettier './**' --write",
     "lint": "eslint src"
   },

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -20,6 +20,7 @@ import {
   addAppToUnload
 } from "../lifecycles/unload.js";
 import { formatErrorMessage } from "./app-errors.js";
+import { isInBrowser } from "../utils/runtime-environment.js";
 
 const apps = [];
 
@@ -109,9 +110,10 @@ export function registerApplication(
     customProps
   });
 
-  ensureJQuerySupport();
-
-  reroute();
+  if (isInBrowser) {
+    ensureJQuerySupport();
+    reroute();
+  }
 }
 
 export function checkActivityFunctions(location) {

--- a/src/single-spa.js
+++ b/src/single-spa.js
@@ -37,6 +37,8 @@ export {
 } from "./applications/app.helpers.js";
 
 import devtools from "./devtools/devtools";
-if (window && window.__SINGLE_SPA_DEVTOOLS__) {
+import { isInBrowser } from "./utils/runtime-environment.js";
+
+if (isInBrowser && window.__SINGLE_SPA_DEVTOOLS__) {
   window.__SINGLE_SPA_DEVTOOLS__.exposedMethods = devtools;
 }

--- a/src/start.js
+++ b/src/start.js
@@ -10,7 +10,9 @@ export function start(opts) {
   if (opts && opts.urlRerouteOnly) {
     setUrlRerouteOnly(opts.urlRerouteOnly);
   }
-  reroute();
+  if (isInBrowser) {
+    reroute();
+  }
 }
 
 export function isStarted() {

--- a/src/start.js
+++ b/src/start.js
@@ -1,6 +1,7 @@
 import { reroute } from "./navigation/reroute.js";
 import { formatErrorMessage } from "./applications/app-errors.js";
 import { setUrlRerouteOnly } from "./navigation/navigation-events.js";
+import { isInBrowser } from "./utils/runtime-environment.js";
 
 let started = false;
 
@@ -16,14 +17,16 @@ export function isStarted() {
   return started;
 }
 
-setTimeout(() => {
-  if (!started) {
-    console.warn(
-      formatErrorMessage(
-        1,
-        __DEV__ &&
-          `singleSpa.start() has not been called, 5000ms after single-spa was loaded. Before start() is called, apps can be declared and loaded, but not bootstrapped or mounted.`
-      )
-    );
-  }
-}, 5000);
+if (isInBrowser) {
+  setTimeout(() => {
+    if (!started) {
+      console.warn(
+        formatErrorMessage(
+          1,
+          __DEV__ &&
+            `singleSpa.start() has not been called, 5000ms after single-spa was loaded. Before start() is called, apps can be declared and loaded, but not bootstrapped or mounted.`
+        )
+      );
+    }
+  }, 5000);
+}

--- a/src/utils/runtime-environment.js
+++ b/src/utils/runtime-environment.js
@@ -1,0 +1,1 @@
+export const isInBrowser = typeof window !== "undefined";


### PR DESCRIPTION
This is for being able to run the root config on the server in order to determine which single-spa applications should be server rendered.

```js
// now works in nodejs
const singleSpa = require('single-spa');

singleSpa.registerApplication(...)
singleSpa.checkActivityFunctions({pathname: '/app1'})
```

This makes all output bundles work in either node or browser. An alternative approach would be to  create a cjs version of single-spa. Doing so would keep the bundle size lower for both browser and node versions, but would raise the question of what we set the `"main"` field as in the package json (would it be the cjs node version? or the umd browser version). To avoid that problem, I implemented this as a runtime check. I think that it's probably fine from a perf standpoint. Open to other thoughts on it.

I also manually verified that single-spa still works when bundled via webpack - webpack doesn't change the isInBrowser check by rewriting things for dead code elimination