### PR TITLE
feat: correct parcel typings

### DIFF
--- a/src/parcels/mount-parcel.js
+++ b/src/parcels/mount-parcel.js
@@ -207,7 +207,7 @@ export function mountParcel(config, customProps) {
     if (config.update) {
       parcel.update = flattenFnArray(config, "update");
       externalRepresentation.update = function (customProps) {
-        parcel.customProps = { ...parcel.customProps, ...customProps };
+        parcel.customProps = customProps;
 
         return promiseWithoutReturnValue(toUpdatePromise(parcel));
       };

--- a/src/parcels/mount-parcel.js
+++ b/src/parcels/mount-parcel.js
@@ -207,7 +207,7 @@ export function mountParcel(config, customProps) {
     if (config.update) {
       parcel.update = flattenFnArray(config, "update");
       externalRepresentation.update = function (customProps) {
-        parcel.customProps = customProps;
+        parcel.customProps = { ...parcel.customProps, ...customProps };
 
         return promiseWithoutReturnValue(toUpdatePromise(parcel));
       };

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -6,18 +6,18 @@ declare module "single-spa" {
   export type AppProps = {
     name: string;
     singleSpa: any;
-    mountParcel(parcelConfig: ParcelConfig, customProps: object): Parcel;
+    mountParcel(
+      parcelConfig: ParcelConfig,
+      customProps: ParcelProps & object
+    ): Parcel;
   };
 
   export type ParcelConfig =
     | ParcelConfigObject
     | (() => Promise<ParcelConfigObject>);
 
-  type ParcelConfigObject = {
-    name?: string;
-    customProps: object;
-    domElement: HTMLElement;
-  } & LifeCycles;
+  type ParcelProps = { domElement: HTMLElement };
+  type ParcelConfigObject = { name?: string } & LifeCycles;
 
   type Parcel = {
     mount(): Promise<null>;
@@ -149,6 +149,6 @@ declare module "single-spa" {
   // './parcels/mount-parcel.js'
   export function mountRootParcel(
     parcelConfig: ParcelConfig,
-    parcelProps: object
+    parcelProps: ParcelProps & object
   ): Parcel;
 }


### PR DESCRIPTION
1. the customProps and domElement prop of parcelConfig seems like never be read in source code while calling moutParcel/mountRootParcel.
2. ~~Could `parcel.update(props)` shallow merge with the previous one? just like what `this.setState(newState)` does in react.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/single-spa/single-spa/500)
<!-- Reviewable:end -->
