### PR TITLE
feat: export StartOpts typing

### DIFF
--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -49,7 +49,7 @@ declare module "single-spa" {
     update?: (config: T & AppProps) => Promise<any>;
   };
 
-  type StartOpts = {
+  export type StartOpts = {
     urlRerouteOnly?: boolean;
   };
 


### PR DESCRIPTION
It would be very useful if single-spa could export the StartOpts typing as we could expand with the source truth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/single-spa/single-spa/501)
<!-- Reviewable:end -->
