### PR TITLE
the esm bundle now supports ie11 again

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,12 @@ export default (async () => [
         sourcemap: true,
         banner: generateBanner("SystemJS"),
       },
+      {
+        file: `./lib/esm/single-spa${isProduction ? ".min" : ".dev"}.js`,
+        format: "esm",
+        sourcemap: true,
+        banner: generateBanner("ESM"),
+      },
     ],
     plugins: [
       replace(replaceOpts),
@@ -58,10 +64,10 @@ export default (async () => [
   {
     input: "./src/single-spa.js",
     output: {
-      file: `./lib/esm/single-spa${isProduction ? ".min" : ".dev"}.js`,
+      file: `./lib/es2015/single-spa${isProduction ? ".min" : ".dev"}.js`,
       format: "esm",
       sourcemap: true,
-      banner: generateBanner("ESM"),
+      banner: generateBanner("ES2015"),
     },
     plugins: [
       replace(replaceOpts),


### PR DESCRIPTION
anyone using a bundler will now get ie11 support back, and those that don't support it will get larger bundles.

to help mitigate the bundle size for those that don't need to support ie11, and for those that use single-spa as an in-browser module, an additional bundle called es2015 has been created to fit that need.

fixes #516 

I confirmed that the `/esm/` output bundle no longer has arrow functions and template literals, both of which ie11 don't support. and the `/es2015/` bundle still has those things.