### PR TITLE
chore (NavigationEvents)[#528]: Identify extraneous popstate event on push/replace state

### DIFF
--- a/spec/apis/navigate-to-url.spec.js
+++ b/spec/apis/navigate-to-url.spec.js
@@ -66,7 +66,7 @@ describe("navigateToUrl", function () {
     singleSpa.navigateToUrl("/start-path#a/other");
     expectPathAndHashToEqual("/start-path#a/other");
   });
-  
+
   it(`should update hash when destination doesn't contain domain, but same path and same query`, function () {
     window.history.pushState(null, null, "/start-path?yoshi=best#a/other");
     singleSpa.navigateToUrl("/start-path?yoshi=best#a/other");
@@ -133,7 +133,8 @@ describe("navigateToUrl", function () {
 describe("window.history.pushState", () => {
   // https://github.com/single-spa/single-spa/issues/224 and https://github.com/single-spa/single-spa-angular/issues/49
   // We need a popstate event even though the browser doesn't do one by default when you call pushState, so that
-  // all the applications can reroute.
+  // all the applications can reroute. We explicitly identify this extraneous event by setting singleSpa=true and
+  // originalMethodName=<pushState|replaceState> on the event instance.
   it("should fire a popstate event when history.pushState is called", function () {
     return singleSpa.triggerAppChange().then(() => {
       return new Promise((resolve, reject) => {
@@ -144,6 +145,8 @@ describe("window.history.pushState", () => {
           expect(evt instanceof PopStateEvent).toBe(true);
           expect(window.location.pathname).toBe("/new-url");
           expect(evt.state).toBe(newHistoryState);
+          expect(evt.singleSpa).toBe(true);
+          expect(evt.originalMethodName).toBe("pushState");
           window.removeEventListener("popstate", popstateListener);
           resolve();
         }
@@ -153,7 +156,8 @@ describe("window.history.pushState", () => {
 
   // https://github.com/single-spa/single-spa/issues/224 and https://github.com/single-spa/single-spa-angular/issues/49
   // We need a popstate event even though the browser doesn't do one by default when you call replaceState, so that
-  // all the applications can reroute.
+  // all the applications can reroute. We explicitly identify this extraneous event by setting singleSpa=true and
+  // originalMethodName=<pushState|replaceState> on the event instance.
   it("should fire a popstate event when history.replaceState is called", function () {
     return singleSpa.triggerAppChange().then(() => {
       return new Promise((resolve, reject) => {
@@ -164,6 +168,8 @@ describe("window.history.pushState", () => {
           expect(evt instanceof PopStateEvent).toBe(true);
           expect(window.location.pathname).toBe("/new-url");
           expect(evt.state).toBe(newHistoryState);
+          expect(evt.singleSpa).toBe(true);
+          expect(evt.originalMethodName).toBe("replaceState");
           window.removeEventListener("popstate", popstateListener);
           resolve();
         }

--- a/spec/apis/navigate-to-url.spec.js
+++ b/spec/apis/navigate-to-url.spec.js
@@ -134,7 +134,7 @@ describe("window.history.pushState", () => {
   // https://github.com/single-spa/single-spa/issues/224 and https://github.com/single-spa/single-spa-angular/issues/49
   // We need a popstate event even though the browser doesn't do one by default when you call pushState, so that
   // all the applications can reroute. We explicitly identify this extraneous event by setting singleSpa=true and
-  // originalMethodName=<pushState|replaceState> on the event instance.
+  // singleSpaTrigger=<pushState|replaceState> on the event instance.
   it("should fire a popstate event when history.pushState is called", function () {
     return singleSpa.triggerAppChange().then(() => {
       return new Promise((resolve, reject) => {
@@ -146,7 +146,7 @@ describe("window.history.pushState", () => {
           expect(window.location.pathname).toBe("/new-url");
           expect(evt.state).toBe(newHistoryState);
           expect(evt.singleSpa).toBe(true);
-          expect(evt.originalMethodName).toBe("pushState");
+          expect(evt.singleSpaTrigger).toBe("pushState");
           window.removeEventListener("popstate", popstateListener);
           resolve();
         }
@@ -157,7 +157,7 @@ describe("window.history.pushState", () => {
   // https://github.com/single-spa/single-spa/issues/224 and https://github.com/single-spa/single-spa-angular/issues/49
   // We need a popstate event even though the browser doesn't do one by default when you call replaceState, so that
   // all the applications can reroute. We explicitly identify this extraneous event by setting singleSpa=true and
-  // originalMethodName=<pushState|replaceState> on the event instance.
+  // singleSpaTrigger=<pushState|replaceState> on the event instance.
   it("should fire a popstate event when history.replaceState is called", function () {
     return singleSpa.triggerAppChange().then(() => {
       return new Promise((resolve, reject) => {
@@ -169,7 +169,7 @@ describe("window.history.pushState", () => {
           expect(window.location.pathname).toBe("/new-url");
           expect(evt.state).toBe(newHistoryState);
           expect(evt.singleSpa).toBe(true);
-          expect(evt.originalMethodName).toBe("replaceState");
+          expect(evt.singleSpaTrigger).toBe("replaceState");
           window.removeEventListener("popstate", popstateListener);
           resolve();
         }

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -153,20 +153,18 @@ if (isInBrowser) {
     // We need a popstate event even though the browser doesn't do one by default when you call replaceState, so that
     // all the applications can reroute. We explicitly identify this extraneous event by setting singleSpa=true and
     // singleSpaTrigger=<pushState|replaceState> on the event instance.
+    let evt;
     try {
-      const evt = new PopStateEvent("popstate", { state });
-      evt.singleSpa = true;
-      evt.singleSpaTrigger = originalMethodName;
-      return evt;
+      evt = new PopStateEvent("popstate", { state });
     } catch (err) {
       // IE 11 compatibility https://github.com/single-spa/single-spa/issues/299
       // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-html5e/bd560f47-b349-4d2c-baa8-f1560fb489dd
-      const evt = document.createEvent("PopStateEvent");
+      evt = document.createEvent("PopStateEvent");
       evt.initPopStateEvent("popstate", false, false, state);
-      evt.singleSpa = true;
-      evt.singleSpaTrigger = originalMethodName;
-      return evt;
     }
+    evt.singleSpa = true;
+    evt.singleSpaTrigger = originalMethodName;
+    return evt;
   }
 
   /* For convenience in `onclick` attributes, we expose a global function for navigating to

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -152,17 +152,19 @@ if (isInBrowser) {
     // https://github.com/single-spa/single-spa/issues/224 and https://github.com/single-spa/single-spa-angular/issues/49
     // We need a popstate event even though the browser doesn't do one by default when you call replaceState, so that
     // all the applications can reroute. We explicitly identify this extraneous event by setting singleSpa=true and
-    // originalMethodName=<pushState|replaceState> on the event instance.
+    // singleSpaTrigger=<pushState|replaceState> on the event instance.
     try {
       const evt = new PopStateEvent("popstate", { state });
       evt.singleSpa = true;
-      evt.originalMethodName = originalMethodName;
+      evt.singleSpaTrigger = originalMethodName;
       return evt;
     } catch (err) {
       // IE 11 compatibility https://github.com/single-spa/single-spa/issues/299
       // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-html5e/bd560f47-b349-4d2c-baa8-f1560fb489dd
       const evt = document.createEvent("PopStateEvent");
       evt.initPopStateEvent("popstate", false, false, state);
+      evt.singleSpa = true;
+      evt.singleSpaTrigger = originalMethodName;
       return evt;
     }
   }


### PR DESCRIPTION
## Summary

Addresses #528 by adding properties to the `PopStateEvent` instance which identify the event as being generated by SingleSpa and indicate which original history method triggered it.

### Code Change

Update the `PopStateEvent` returned by `createPopStateEvent` to look like:

```js
const evt = new PopStateEvent("popstate", { state });
evt.singleSpa = true;
evt.singleSpaTrigger = originalMethodName; // <pushState|replaceState>
```

## Test Plan

Unit tests updated to assert these additional attributes.

