### PR TITLE
Allow calling checkActivityFunctions without location object.

### DIFF
--- a/spec/apis/check-activity-functions.spec.js
+++ b/spec/apis/check-activity-functions.spec.js
@@ -87,6 +87,11 @@ describe(`checkActivityFunctionsApi`, () => {
     });
   });
 
+  it(`uses the window.location by default`, () => {
+    window.location.hash = "#one";
+    expect(singleSpa.checkActivityFunctions()).toEqual(["test1"]);
+  });
+
   it(`returns 'test1' when the location contains 'one'`, () => {
     const wLocation = mockWindowLocation("http://google.com/one");
     expect(singleSpa.checkActivityFunctions(wLocation)).toEqual(["test1"]);

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -89,7 +89,7 @@ export function registerApplication(
   }
 }
 
-export function checkActivityFunctions(location) {
+export function checkActivityFunctions(location = window.location) {
   return apps.filter((app) => app.activeWhen(location)).map(toName);
 }
 


### PR DESCRIPTION
[This documentation](https://single-spa.js.org/docs/api#checkactivityfunctions) indicates that you can call `checkActivityFunctions` with no arguments and it will default to window.location. However, that wasn't true in the code. This PR fixes that.