### PR TITLE
 perf(reroute): only call activity functions one time per reroute. 

### DIFF
--- a/src/applications/app.helpers.js
+++ b/src/applications/app.helpers.js
@@ -18,22 +18,6 @@ export function isActive(app) {
   return app.status === MOUNTED;
 }
 
-export function isntActive(app) {
-  return !isActive(app);
-}
-
-export function isLoaded(app) {
-  return (
-    app.status !== NOT_LOADED &&
-    app.status !== LOADING_SOURCE_CODE &&
-    app.status !== LOAD_ERROR
-  );
-}
-
-export function isntLoaded(app) {
-  return !isLoaded(app);
-}
-
 export function shouldBeActive(app) {
   try {
     return app.activeWhen(window.location);
@@ -41,23 +25,6 @@ export function shouldBeActive(app) {
     handleAppError(err, app, SKIP_BECAUSE_BROKEN);
     return false;
   }
-}
-
-export function shouldntBeActive(app) {
-  return !shouldBeActive(app);
-}
-
-export function notSkipped(item) {
-  return (
-    item !== SKIP_BECAUSE_BROKEN &&
-    (!item || item.status !== SKIP_BECAUSE_BROKEN)
-  );
-}
-
-export function withoutLoadErrors(app) {
-  return app.status === LOAD_ERROR
-    ? new Date().getTime() - app.loadErrorTime >= 200
-    : true;
 }
 
 export function toName(app) {

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -29,10 +29,14 @@ export function getAppChanges() {
     appsToUnmount = [],
     appsToLoad = [],
     appsToMount = [];
+
+  // We re-attempt to download applications in LOAD_ERROR after a timeout of 200 milliseconds
   const currentTime = new Date().getTime();
+
   apps.forEach((app) => {
     const appShouldBeActive =
       app.status !== SKIP_BECAUSE_BROKEN && shouldBeActive(app);
+
     switch (app.status) {
       case LOAD_ERROR:
         if (currentTime - app.loadErrorTime >= 200) {

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -65,7 +65,7 @@ export function getAppChanges() {
     }
   });
 
-  return [appsToUnload, appsToUnmount, appsToLoad, appsToMount];
+  return { appsToUnload, appsToUnmount, appsToLoad, appsToMount };
 }
 
 export function getMountedApps() {

--- a/src/lifecycles/unload.js
+++ b/src/lifecycles/unload.js
@@ -3,7 +3,6 @@ import {
   UNLOADING,
   NOT_LOADED,
   SKIP_BECAUSE_BROKEN,
-  isntActive,
   toName,
 } from "../applications/app.helpers.js";
 import { handleAppError } from "../applications/app-errors.js";
@@ -94,10 +93,4 @@ export function addAppToUnload(app, promiseGetter, resolve, reject) {
 
 export function getAppUnloadInfo(appName) {
   return appsToUnload[appName];
-}
-
-export function getAppsToUnload() {
-  return Object.keys(appsToUnload)
-    .map((appName) => appsToUnload[appName].app)
-    .filter(isntActive);
 }

--- a/src/navigation/reroute.js
+++ b/src/navigation/reroute.js
@@ -4,11 +4,7 @@ import { toLoadPromise } from "../lifecycles/load.js";
 import { toBootstrapPromise } from "../lifecycles/bootstrap.js";
 import { toMountPromise } from "../lifecycles/mount.js";
 import { toUnmountPromise } from "../lifecycles/unmount.js";
-import {
-  getMountedApps,
-  getAppStatus,
-  getAppChanges,
-} from "../applications/apps.js";
+import { getAppStatus, getAppChanges } from "../applications/apps.js";
 import { callCapturedEventListeners } from "./navigation-events.js";
 import { toUnloadPromise } from "../lifecycles/unload.js";
 import {

--- a/src/navigation/reroute.js
+++ b/src/navigation/reroute.js
@@ -39,20 +39,21 @@ export function reroute(pendingPromises = [], eventArguments) {
     });
   }
 
-  const [
+  const {
     appsToUnload,
     appsToUnmount,
     appsToLoad,
     appsToMount,
-  ] = getAppChanges();
+  } = getAppChanges();
   let appsThatChanged;
 
   if (isStarted()) {
     appChangeUnderway = true;
-    appsThatChanged = appsToUnload
-      .concat(appsToLoad)
-      .concat(appsToUnmount)
-      .concat(appsToMount);
+    appsThatChanged = appsToUnload.concat(
+      appsToLoad,
+      appsToUnmount,
+      appsToMount
+    );
     return performAppChanges();
   } else {
     appsThatChanged = appsToLoad;

--- a/src/navigation/reroute.js
+++ b/src/navigation/reroute.js
@@ -4,7 +4,11 @@ import { toLoadPromise } from "../lifecycles/load.js";
 import { toBootstrapPromise } from "../lifecycles/bootstrap.js";
 import { toMountPromise } from "../lifecycles/mount.js";
 import { toUnmountPromise } from "../lifecycles/unmount.js";
-import { getAppStatus, getAppChanges } from "../applications/apps.js";
+import {
+  getAppStatus,
+  getAppChanges,
+  getMountedApps,
+} from "../applications/apps.js";
 import { callCapturedEventListeners } from "./navigation-events.js";
 import { toUnloadPromise } from "../lifecycles/unload.js";
 import {
@@ -140,10 +144,7 @@ export function reroute(pendingPromises = [], eventArguments) {
   }
 
   function finishUpAndReturn() {
-    const returnValue = appsToLoad
-      .concat(appsToMount)
-      .filter((app) => getAppStatus(app) === MOUNTED)
-      .map(toName);
+    const returnValue = getMountedApps();
     pendingPromises.forEach((promise) => promise.resolve(returnValue));
 
     try {


### PR DESCRIPTION
I started thinking about #545 and how to implement it and realized that our current implementation of reroute has some performance problems. It will call every application's activity function at least 5 times every reroute. I decided to embark on a refactor to see if it would be easy / possible to only call the activity functions once per reroute. It didn't turn out to be extremely easy, but I am pleased with the results.

The impact on bundle size was a decrease of 2 bytes - so essentially same as where we started.

This PR is sort of scary as it's a fairly large refactor. I appreciate as many thorough eyes as possible looking at it. A fair amount of tests broke when I first worked on it and it took a while to get all the tests passing again. I take that as a good sign that our tests are catching things.