### PR TITLE
before-app-change and before-no-app change events. Resolves #545

### DIFF
--- a/spec/apis/single-spa-events-api.spec.js
+++ b/spec/apis/single-spa-events-api.spec.js
@@ -47,9 +47,7 @@ describe(`events api :`, () => {
       russellApp,
       () => window.location.hash.indexOf("#/russell") === 0
     );
-    singleSpa.registerApplication("boom", boomApp, () => {
-      return boom;
-    });
+    singleSpa.registerApplication("boom", boomApp, () => boom);
     singleSpa.start();
   });
 

--- a/spec/apis/single-spa-events-api.spec.js
+++ b/spec/apis/single-spa-events-api.spec.js
@@ -454,6 +454,10 @@ describe(`events api :`, () => {
           );
           expect(singleSpa.getAppStatus("russell")).toBe(singleSpa.MOUNTED);
           window.addEventListener("single-spa:before-app-change", finishTest);
+          window.addEventListener(
+            "single-spa:before-no-app-change",
+            finishTest
+          );
           boom = true;
           window.location.hash = `#not-a-real-app`;
 
@@ -462,6 +466,11 @@ describe(`events api :`, () => {
               "single-spa:before-app-change",
               finishTest
             );
+            window.removeEventListener(
+              "single-spa:before-no-app-change",
+              finishTest
+            );
+            expect(evt.type).toBe("single-spa:before-app-change");
             expect(singleSpa.getAppStatus("boom")).toMatch(
               /NOT_MOUNTED|NOT_LOADED/
             );

--- a/spec/apis/single-spa-events-api.spec.js
+++ b/spec/apis/single-spa-events-api.spec.js
@@ -443,7 +443,7 @@ describe(`events api :`, () => {
   });
 
   describe(`single-spa:before-app-change`, () => {
-    it(`is fired when before apps will change, and not fired if no apps are changing`, (done) => {
+    it(`is fired before apps will change, and not fired if no apps are changing`, (done) => {
       window.location.hash = `#/russell`;
 
       singleSpa
@@ -489,7 +489,7 @@ describe(`events api :`, () => {
   });
 
   describe(`single-spa:before-no-app-change`, () => {
-    it(`is fired when before apps will not change, and not fired if apps are changing`, (done) => {
+    it(`is fired before apps will not change, and not fired if apps are changing`, (done) => {
       window.location.hash = `#/russell`;
 
       singleSpa


### PR DESCRIPTION
See #545. Use case for this is "place a loader while apps are changing, then remove loader once they're done"