### PR TITLE
Add safe guards to ie11

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,32 @@
   },
   "globals": {
     "__DEV__": true
+  },
+  "plugins": [
+    "es5"
+  ],
+  "rules": {
+    "es5/no-es6-methods": "error",
+    "es5/no-es6-static-methods": "error",
+    "es5/no-binary-and-octal-literals": "error",
+    "es5/no-classes": "error",
+    "es5/no-for-of": "error",
+    "es5/no-generators": "error",
+    "es5/no-object-super": "error",
+    "es5/no-typeof-symbol": "error",
+    "es5/no-unicode-code-point-escape": "error",
+    "es5/no-unicode-regex": "error",
+    "es5/no-computed-properties": "off",
+    "es5/no-destructuring": "off",
+    "es5/no-default-parameters": "off",
+    "es5/no-spread": "off",
+    "es5/no-modules": "off",
+    "es5/no-exponentiation-operator": "off",
+    "es5/no-block-scoping": "off",
+    "es5/no-arrow-functions": "off",
+    "es5/no-shorthand-properties": "off",
+    "es5/no-rest-parameters": "off",
+    "es5/no-template-literals": "off"
+
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,5 @@
     "es5/no-shorthand-properties": "off",
     "es5/no-rest-parameters": "off",
     "es5/no-template-literals": "off"
-
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint": "6.8.0",
     "eslint-config-canopy": "2.3.0",
     "eslint-config-important-stuff": "^1.1.0",
+    "eslint-plugin-es5": "^1.5.0",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
     "prettier": "^2.0.2",

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -137,7 +137,7 @@ export function checkActivityFunctions(location = window.location) {
 }
 
 export function unregisterApplication(appName) {
-  if (!apps.find((app) => toName(app) === appName)) {
+  if (apps.filter((app) => toName(app) === appName).length === 0) {
     throw Error(
       formatErrorMessage(
         25,
@@ -149,7 +149,7 @@ export function unregisterApplication(appName) {
   }
 
   return unloadApplication(appName).then(() => {
-    const appIndex = apps.findIndex((app) => toName(app) === appName);
+    const appIndex = apps.map(toName).indexOf(appName);
     apps.splice(appIndex, 1);
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,6 +2358,11 @@ eslint-formatter-pretty@^1.3.0:
     plur "^2.1.2"
     string-width "^2.0.0"
 
+eslint-plugin-es5@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz#aab19af3d4798f7924bba309bc4f87087280fbba"
+  integrity sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==
+
 eslint-plugin-react-hooks@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"


### PR DESCRIPTION
# Why?
We are still supporting IE11 but we are not adding polyfills for new ES2015+ methods on Object,Array,String etc, so to avoid issues like the one fixed here: https://github.com/single-spa/single-spa/issues/557 I'm proposing we add some linting to help us avoid releasing another broken IE11 version

When linting, it caught 2 more methods I had no idea that didnt work on IE!
- Array.prototype.find: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
- Array.prototype.findIndex: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
(I'm using Browser compatibility section)

Regarding the rules, this is debatable but I left some syntax babel transforms when building as `error` due to some messages I came across in the repo (like this one: [link](https://github.com/single-spa/single-spa/blob/master/src/utils/find.js)) which takes into consideration the weight of transpiled code.

Also, I came across this other plugin: https://github.com/Volox/eslint-plugin-ie11#supported-rules but has so few contributions (even less than eslint-plugin-es5) that I'm not sure if I should also add.