### PR TITLE
fix(activeWhen): activeWhen with string literal should be exact match

### DIFF
--- a/spec/apis/path-to-active-when.spec.js
+++ b/spec/apis/path-to-active-when.spec.js
@@ -31,6 +31,34 @@ describe(`pathToActiveWhen`, () => {
       ).toBe(false);
     });
 
+    it("Should generate correct regex for '/pathname/'", () => {
+      expect(toDynamicPathValidatorRegex("/pathname/").test("/pathname")).toBe(
+        false
+      );
+      expect(toDynamicPathValidatorRegex("/pathname/").test("/pathname/")).toBe(
+        true
+      );
+      expect(
+        toDynamicPathValidatorRegex("/pathname/").test("/pathname/extra")
+      ).toBe(true);
+    });
+
+    it("Should generate correct regex for '/pathname/:dynamic/'", () => {
+      expect(
+        toDynamicPathValidatorRegex("/pathname/:dynamic/").test("/pathname/123")
+      ).toBe(false);
+      expect(
+        toDynamicPathValidatorRegex("/pathname/:dynamic/").test(
+          "/pathname/123/"
+        )
+      ).toBe(true);
+      expect(
+        toDynamicPathValidatorRegex("/pathname/:dynamic/").test(
+          "/pathname/123/extra"
+        )
+      ).toBe(true);
+    });
+
     it("Should generate correct regex for '/#/pathname'", () => {
       expect(
         toDynamicPathValidatorRegex("/#/pathname").test("/#/pathname")

--- a/spec/apis/path-to-active-when.spec.js
+++ b/spec/apis/path-to-active-when.spec.js
@@ -24,6 +24,11 @@ describe(`pathToActiveWhen`, () => {
           "/pathname/anything/everything"
         )
       ).toBe(true);
+      expect(
+        toDynamicPathValidatorRegex("/pathname").test(
+          "/pathnameExtraShouldNotMatch"
+        )
+      ).toBe(false);
     });
 
     it("Should generate correct regex for '/#/pathname'", () => {
@@ -46,6 +51,11 @@ describe(`pathToActiveWhen`, () => {
           "/#/pathname/1/notDynamic"
         )
       ).toBe(true);
+      expect(
+        toDynamicPathValidatorRegex("/#/pathname/:dynamic/notDynamic").test(
+          "/#/pathname/1/notDynamicExtra"
+        )
+      ).toBe(false);
       expect(
         toDynamicPathValidatorRegex("/#/pathname/:dynamic/notDynamic").test(
           "/#/pathname/1/notDynamic/"

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -443,6 +443,11 @@ export function toDynamicPathValidatorRegex(path) {
     regexStr += inDynamic
       ? anyCharMaybeTrailingSlashRegex
       : commonStringSubPath;
+
+    if (index === path.length && !inDynamic) {
+      regexStr = `(${regexStr}$)|(${regexStr}\\/.*$)`;
+    }
+
     inDynamic = !inDynamic;
     lastIndex = index;
   }

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -445,7 +445,11 @@ export function toDynamicPathValidatorRegex(path) {
       : commonStringSubPath;
 
     if (index === path.length && !inDynamic) {
-      regexStr = `(${regexStr}$)|(${regexStr}\\/.*$)`;
+      regexStr =
+        // use charAt instead as we could not use es6 method endsWith
+        regexStr.charAt(regexStr.length - 1) === "/"
+          ? `${regexStr}.*$`
+          : `${regexStr}(\/.*)?$`;
     }
 
     inDynamic = !inDynamic;


### PR DESCRIPTION
Current behavior
✅ `/path` -> `/pathExtra`
✅ `/:dynamic/path` -> `/abc/pathExtra`

Expected behavior
✅ `/path` -> `/path/extra`
✅ `/:dynamic/path` -> `/abc/path/extra`
❌ `/path` -> `/pathExtra`
❌ `/:dynamic/path` -> `/abc/pathExtra`

resolve https://github.com/umijs/qiankun/pull/609
resolve https://github.com/umijs/qiankun/issues/607

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/single-spa/single-spa/565)
<!-- Reviewable:end -->
