### PR TITLE
Fix bug with delayed call to start(). See #555.

### DIFF
--- a/spec/apps/delayed-start/delayed-start.app.js
+++ b/spec/apps/delayed-start/delayed-start.app.js
@@ -1,0 +1,5 @@
+export async function bootstrap() {}
+
+export async function mount() {}
+
+export async function unmount() {}

--- a/spec/apps/delayed-start/delayed-start.spec.js
+++ b/spec/apps/delayed-start/delayed-start.spec.js
@@ -1,0 +1,55 @@
+import * as singleSpa from "single-spa";
+
+describe(`delayed-start`, () => {
+  let myApp;
+
+  // https://github.com/single-spa/single-spa/issues/555
+  it("will mount an application that began loading before start() was called", async () => {
+    let loadPromise;
+
+    singleSpa.registerApplication({
+      name: "delayed-start",
+      app: () =>
+        (loadPromise = (async () => {
+          // wait a tick before resolving the promise
+          await tick();
+          return await import("./delayed-start.app");
+        })()),
+      activeWhen: () => true,
+    });
+
+    expect(singleSpa.getAppStatus("delayed-start")).toBe(singleSpa.NOT_LOADED);
+
+    await tick();
+
+    expect(singleSpa.getAppStatus("delayed-start")).toBe(
+      singleSpa.LOADING_SOURCE_CODE
+    );
+
+    await singleSpa.triggerAppChange();
+
+    singleSpa.start();
+
+    await Promise.all([loadPromise, routingEvent()]);
+
+    // Before fixing https://github.com/single-spa/single-spa/issues/555,
+    // this assertion failed - status was NOT_BOOTSTRAPPED
+    expect(singleSpa.getAppStatus("delayed-start")).toBe(singleSpa.MOUNTED);
+  });
+});
+
+function tick() {
+  return new Promise((resolve) => {
+    setTimeout(resolve);
+  });
+}
+
+function routingEvent() {
+  return new Promise((resolve) => {
+    window.addEventListener("single-spa:routing-event", handleEvent);
+    function handleEvent() {
+      window.removeEventListener("single-spa:routing-event", handleEvent);
+      resolve();
+    }
+  });
+}

--- a/spec/apps/delayed-start/delayed-start.spec.js
+++ b/spec/apps/delayed-start/delayed-start.spec.js
@@ -28,6 +28,10 @@ describe(`delayed-start`, () => {
 
     await singleSpa.triggerAppChange();
 
+    expect(singleSpa.getAppStatus("delayed-start")).toBe(
+      singleSpa.NOT_BOOTSTRAPPED
+    );
+
     singleSpa.start();
 
     await Promise.all([loadPromise, routingEvent()]);

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -8,6 +8,7 @@ import {
   MOUNTED,
   LOAD_ERROR,
   SKIP_BECAUSE_BROKEN,
+  LOADING_SOURCE_CODE,
   shouldBeActive,
 } from "./app.helpers.js";
 import { reroute } from "../navigation/reroute.js";
@@ -44,6 +45,7 @@ export function getAppChanges() {
         }
         break;
       case NOT_LOADED:
+      case LOADING_SOURCE_CODE:
         if (appShouldBeActive) {
           appsToLoad.push(app);
         }


### PR DESCRIPTION
See #555. This is a regression bug that was caused by https://github.com/single-spa/single-spa/pull/546.

The bug occurs when you call `start()` when an application is in `LOADING_SOURCE_CODE` status. The reason is that there are two reroutes in that scenario - the one caused by `registerApplication` and the one caused by `start()`. The reroute caused by `registerApplication` will not result in any applications being mounted, since it is called before start() is called. And the reroute caused by `start()` will also not cause the application to be mounted, since in 5.5.0 applications in LOADING_SOURCE_CODE status are no longer considered "apps to load."

See the code snippets below to see the difference in behavior between 5.4.0 and 5.5.0.

Behavior in 5.4.0:

https://github.com/single-spa/single-spa/blob/5e02f521ecaaa5fe8766aebc21102ab1def6a449/src/applications/apps.js#L96-L102

https://github.com/single-spa/single-spa/blob/5e02f521ecaaa5fe8766aebc21102ab1def6a449/src/applications/app.helpers.js#L33-L35

https://github.com/single-spa/single-spa/blob/5e02f521ecaaa5fe8766aebc21102ab1def6a449/src/applications/app.helpers.js#L25-L31

Notice that applications in `LOADING_SOURCE_CODE` status were considered "apps to load" in <=5.4.0. Now look at the behavior in single-spa@5.5.0:

https://github.com/single-spa/single-spa/blob/a2723fabf0d1ef7ca59914236defa9006b6f4531/src/applications/apps.js#L41-L50

https://github.com/single-spa/single-spa/blob/a2723fabf0d1ef7ca59914236defa9006b6f4531/src/applications/apps.js#L64