### PR TITLE
Add console warning when single-spa is loaded twice on the same page.

### DIFF
--- a/spec/apis/multiple-instances.spec.js
+++ b/spec/apis/multiple-instances.spec.js
@@ -1,0 +1,24 @@
+describe(`multiple instances of single-spa`, () => {
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, "warn");
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it(`should log a warning to the console when you load single-spa on a page that already has loaded single-spa`, async () => {
+    // This is how we "fool" single-spa into thinking it was already loaded on the page
+    window.singleSpaNavigate = function () {};
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    await import("single-spa");
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "single-spa minified message #41: single-spa has been loaded twice on the page. This can result in unexpected behavior. See https://single-spa.js.org/error/?code=41"
+    );
+  });
+});

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -167,10 +167,20 @@ if (isInBrowser) {
     "replaceState"
   );
 
-  /* For convenience in `onclick` attributes, we expose a global function for navigating to
-   * whatever an <a> tag's href is.
-   */
-  window.singleSpaNavigate = navigateToUrl;
+  if (window.singleSpaNavigate) {
+    console.warn(
+      formatErrorMessage(
+        41,
+        __DEV__ &&
+          "single-spa has been loaded twice on the page. This can result in unexpected behavior."
+      )
+    );
+  } else {
+    /* For convenience in `onclick` attributes, we expose a global function for navigating to
+     * whatever an <a> tag's href is.
+     */
+    window.singleSpaNavigate = navigateToUrl;
+  }
 }
 
 function parseUri(str) {


### PR DESCRIPTION
See https://github.com/single-spa/single-spa/issues/575#issuecomment-641075310 which made me think this would be useful.

Note that this adds a warning, but also alters behavior - now the `singleSpaNavigate` function will always reference the first single-spa instance that was loaded on the page, instead of the last instance. I think that that's a fine change that won't break things for people, since only the single-spa instance used in the root config will respond properly when `singleSpaNavigate` is called. Since the root config is generally the first thing that is loaded, I think this is more likely to fix things for people than break things. However, there is a chance that people are accidentally depending on loading multiple instances and having singleSpaNavigate refer to the most recently loaded single-spa instance.