### PR TITLE
fix: toDymanicPathValidatorRegex-supports-queryParams-and-urlFragments

### DIFF
--- a/spec/apis/path-to-active-when.spec.js
+++ b/spec/apis/path-to-active-when.spec.js
@@ -39,6 +39,7 @@ describe(`pathToActiveWhen`, () => {
       "http://app.com/#/pathname/": true,
       "http://app.com/#/pathname/?query-string=1": true,
       "http://app.com/#/pathname/anything/everything": true,
+      "http://app.com/#/pathname/anything/everything#url-fragment": true,
       "http://app.com/#/pathname/anything/everything?query-string=1": true,
       "http://app.com?query-string=1/#/pathname/anything/everything?query-string=1": true,
       "http://app.com?query-string=1#/pathname/anything/everything?query-string=1": true,

--- a/spec/apis/path-to-active-when.spec.js
+++ b/spec/apis/path-to-active-when.spec.js
@@ -6,6 +6,7 @@ describe(`pathToActiveWhen`, () => {
     expectPathToMatch("/pathname", {
       "http://app.com/pathname": true,
       "http://app.com/pathname?query-string=1": true,
+      "http://app.com/pathname#url-fragment": true,
       "http://app.com/pathname/": true,
       "http://app.com/pathname/?query-string=1": true,
       "http://app.com/pathname/anything/everything": true,
@@ -17,6 +18,7 @@ describe(`pathToActiveWhen`, () => {
     expectPathToMatch("/pathname/", {
       "http://app.com/pathname/": true,
       "http://app.com/pathname/?query-string=1": true,
+      "http://app.com/pathname/#url-fragment": true,
       "http://app.com/pathname/extra": true,
       "http://app.com/pathname": false,
       "http://app.com/pathname?query-string=1": false,

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -457,7 +457,7 @@ export function toDynamicPathValidatorRegex(path) {
         // use charAt instead as we could not use es6 method endsWith
         regexStr.charAt(regexStr.length - 1) === "/"
           ? `${regexStr}.*$`
-          : `${regexStr}(\/.*)?$`;
+          : `${regexStr}([/#?].*)?$`;
     }
 
     inDynamic = !inDynamic;

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -457,7 +457,7 @@ export function toDynamicPathValidatorRegex(path) {
         // use charAt instead as we could not use es6 method endsWith
         regexStr.charAt(regexStr.length - 1) === "/"
           ? `${regexStr}.*$`
-          : `${regexStr}([/#?].*)?$`;
+          : `${regexStr}([/#].*)?$`;
     }
 
     inDynamic = !inDynamic;


### PR DESCRIPTION
A path like `/hello-world` should be active when current pathname has:
a. query params: `/hello-world?abc=def`
b. URL fragments: `/hello-word#abcdef`