### PR TITLE
feat: add file size reporter workflow to PR flow using file-size-impa…

### DIFF
--- a/.github/workflows/file-size-impact.yml
+++ b/.github/workflows/file-size-impact.yml
@@ -1,0 +1,29 @@
+name: file-size-impact
+
+on: pull_request_target
+
+jobs:
+  file-size-impact:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [13.12.0]
+    runs-on: ${{ matrix.os }}
+    name: report file size impact
+    steps:
+      - name: Setup git
+        uses: actions/checkout@v2
+      - name: Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: npm install
+        run: npm install
+      - name: npm run build
+        run: npm run build
+      - name: npm install jsenv-file-size
+        run: npm install --prefix ./.github/workflows/file-size-impact/
+      - name: Report file size impact
+        run: node ./.github/workflows/file-size-impact/report-file-size-impact.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/file-size-impact/.gitignore
+++ b/.github/workflows/file-size-impact/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.github/workflows/file-size-impact/package.json
+++ b/.github/workflows/file-size-impact/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "single-spa-workflow-file-size-impact",
+  "author": "Tiago Stutz",
+  "version": "0.0.1",
+  "description": "",
+  "main": "report-file-size-impact.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@jsenv/file-size-impact": "4.3.0"
+  }
+}

--- a/.github/workflows/file-size-impact/report-file-size-impact.js
+++ b/.github/workflows/file-size-impact/report-file-size-impact.js
@@ -1,0 +1,14 @@
+const { reportFileSizeImpact, readGithubWorkflowEnv } = require("@jsenv/file-size-impact");
+
+reportFileSizeImpact({
+  ...readGithubWorkflowEnv(),
+  projectDirectoryUrl: process.env.GITHUB_WORKSPACE,
+  installCommand: "npm install",
+  buildCommand: "npm run build && rm -rf node_modules",
+  trackingConfig: {
+    dist: {
+      "./lib/**/*": true,
+      "./lib/**/*.map": false,
+    },
+  },
+});


### PR DESCRIPTION
Add .github workflow that calculates and posts the bundle size as a comment in the PR.

@dmail I'd appreciate it if you can take a look at this. I struggled a bit to test this before submitting the PR here to avoid repo noise here. I had set up a kinda sandbox on https://github.com/stutzlab/single-spa/pull/7

refs #515