### PR TITLE
Only reload applications that should be active. Resolves #637.

### DIFF
--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -40,7 +40,7 @@ export function getAppChanges() {
 
     switch (app.status) {
       case LOAD_ERROR:
-        if (currentTime - app.loadErrorTime >= 200) {
+        if (appShouldBeActive && currentTime - app.loadErrorTime >= 200) {
           appsToLoad.push(app);
         }
         break;


### PR DESCRIPTION
See #637. This bug was introduced as part of single-spa@5.0.0 due to the performance-related refactor in https://github.com/single-spa/single-spa/pull/546