### PR TITLE
fix: error message

### DIFF
--- a/src/lifecycles/load.js
+++ b/src/lifecycles/load.js
@@ -79,14 +79,14 @@ export function toLoadPromise(app) {
           if (!validLifecycleFn(appOpts.mount)) {
             validationErrCode = 36;
             if (__DEV__) {
-              validationErrMessage = `does not export a bootstrap function or array of functions`;
+              validationErrMessage = `does not export a mount function or array of functions`;
             }
           }
 
           if (!validLifecycleFn(appOpts.unmount)) {
             validationErrCode = 37;
             if (__DEV__) {
-              validationErrMessage = `does not export a bootstrap function or array of functions`;
+              validationErrMessage = `does not export a unmount function or array of functions`;
             }
           }
 


### PR DESCRIPTION
Better error message when the js file of child application doesn't export a mount or unmount function.