### PR TITLE
Feature/add type for custom event detail

### DIFF
--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -91,8 +91,15 @@ declare module "single-spa" {
     customProps?: T | CustomPropsFn<T>;
   };
 
+  interface SingleSpaNewAppStatus {
+    [key: string]:
+      | "MOUNTED"
+      | "NOT_MOUNTED"
+      | "NOT_LOADED"
+      | "SKIP_BECAUSE_BROKEN";
+  }
   export type SingleSpaCustomEventDetail = {
-    newAppStatuses: {};
+    newAppStatuses: SingleSpaNewAppStatus;
     appsByNewStatus: {
       [MOUNTED]: [];
       [NOT_MOUNTED]: [];

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -98,14 +98,15 @@ declare module "single-spa" {
       | "NOT_LOADED"
       | "SKIP_BECAUSE_BROKEN";
   }
+  interface SingleSpaAppsByNewStatus {
+    [MOUNTED]: [];
+    [NOT_MOUNTED]: [];
+    [NOT_LOADED]: [];
+    [SKIP_BECAUSE_BROKEN]: [];
+  }
   export type SingleSpaCustomEventDetail = {
     newAppStatuses: SingleSpaNewAppStatus;
-    appsByNewStatus: {
-      [MOUNTED]: [];
-      [NOT_MOUNTED]: [];
-      [NOT_LOADED]: [];
-      [SKIP_BECAUSE_BROKEN]: [];
-    };
+    appsByNewStatus: SingleSpaAppsByNewStatus;
     totalAppChanges: number;
     originalEvent?: Event;
     oldUrl: string;

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -91,6 +91,22 @@ declare module "single-spa" {
     customProps?: T | CustomPropsFn<T>;
   };
 
+  export type SingleSpaCustomEventDetail = {
+    newAppStatuses: {};
+    appsByNewStatus: {
+      [MOUNTED]: [];
+      [NOT_MOUNTED]: [];
+      [NOT_LOADED]: [];
+      [SKIP_BECAUSE_BROKEN]: [];
+    };
+    totalAppChanges: number;
+    originalEvent?: Event;
+    oldUrl: string;
+    newUrl: string;
+    navigationIsCanceled: boolean;
+    cancelNavigation?: () => void;
+  };
+
   // ./applications/apps.js
   export function registerApplication<T extends object = {}>(
     appName: string,
@@ -103,9 +119,7 @@ declare module "single-spa" {
     config: RegisterApplicationConfig<T>
   ): void;
 
-  export function unregisterApplication(
-    appName: string,
-  ): Promise<any>;
+  export function unregisterApplication(appName: string): Promise<any>;
 
   export function getMountedApps(): string[];
 

--- a/typings/single-spa.test-d.ts
+++ b/typings/single-spa.test-d.ts
@@ -3,6 +3,9 @@ import {
   mountRootParcel,
   registerApplication,
   pathToActiveWhen,
+  SingleSpaCustomEventDetail,
+  SingleSpaNewAppStatus,
+  SingleSpaAppsByNewStatus,
 } from "single-spa";
 import { expectError, expectType } from "tsd";
 
@@ -39,3 +42,17 @@ registerApplication({
 
 const activeWhen = pathToActiveWhen("/users/:id");
 expectType<boolean>(activeWhen(window.location));
+
+window.addEventListener("single-spa:routing-event", ((
+  evt: CustomEvent<SingleSpaCustomEventDetail>
+) => {
+  expectType<SingleSpaCustomEventDetail>(evt.detail);
+  expectType<SingleSpaNewAppStatus>(evt.detail.newAppStatuses);
+  expectType<SingleSpaAppsByNewStatus>(evt.detail.appsByNewStatus);
+  expectType<number>(evt.detail.totalAppChanges);
+  expectType<Event | undefined>(evt.detail.originalEvent);
+  expectType<string>(evt.detail.oldUrl);
+  expectType<string>(evt.detail.newUrl);
+  expectType<boolean>(evt.detail.navigationIsCanceled);
+  expectType<(() => void) | undefined>(evt.detail.cancelNavigation);
+}) as EventListener);


### PR DESCRIPTION
re: https://github.com/single-spa/single-spa/issues/679

Added type SingleSpaCustomEventDetail.

I manually tested with our local root config by editing `/node_modules/single-spa/typings/single-spa.d.ts` .
I am happy to add a test to `/typings/single-spa.test-d.ts`, but I honestly don't know what to add.

( I think the change to `unregisterApplication` was a formatOnSave casualty. )