### PR TITLE
Add option for exact matches in pathToActiveWhen.

### DIFF
--- a/spec/apis/path-to-active-when.spec.js
+++ b/spec/apis/path-to-active-when.spec.js
@@ -1,5 +1,4 @@
 import { pathToActiveWhen } from "single-spa";
-import { toDynamicPathValidatorRegex } from "../../src/applications/apps";
 
 describe(`pathToActiveWhen`, () => {
   describe("Validate URL on given activeWhen pathname/hashPathname/both", () => {
@@ -106,17 +105,74 @@ describe(`pathToActiveWhen`, () => {
 
     expectPathToMatch(":dynamic/:dynamic", {
       "http://app.com/1/1": true,
+      "http://app.com/1/1/more": true,
     });
+  });
+
+  describe("exact matches", () => {
+    expectPathToMatch(
+      "/pathname",
+      {
+        "http://app.com/pathname": true,
+        "http://app.com/pathname/": true,
+        "http://app.com/pathname/more": false,
+        "http://app.com/pathname/?query": true,
+        "http://app.com/pathname#hash": true,
+        "http://app.com/pathname/#hash": true,
+        "http://app.com/pathname/?query#hash": true,
+      },
+      true
+    );
+
+    expectPathToMatch(
+      ":dynamic",
+      {
+        "http://app.com/1": true,
+        "http://app.com/1/": true,
+        "http://app.com/1/more": false,
+      },
+      true
+    );
+
+    expectPathToMatch(
+      ":dynamic/:dynamic",
+      {
+        "http://app.com/1/1": true,
+        "http://app.com/1/1/": true,
+        "http://app.com/1/1/more": false,
+      },
+      true
+    );
+
+    expectPathToMatch(
+      "/user/:id/settings",
+      {
+        "http://app.com/user/1/settings": true,
+        "http://app.com/user/1/settings/": true,
+        "http://app.com/user/1/settings/account": false,
+      },
+      true
+    );
+
+    expectPathToMatch(
+      "/user/:id/almost",
+      {
+        "http://app.com/user/1/almostt": false,
+      },
+      true
+    );
   });
 });
 
-function expectPathToMatch(dynamicPath, asserts) {
+function expectPathToMatch(dynamicPath, asserts, exactMatch) {
   const print = (path) => (path === "" ? "empty string ('')" : path);
   Object.entries(asserts).forEach(([path, expectTo]) => {
     it(`expects path ${print(dynamicPath)} to${
       expectTo ? "" : " not"
     } match ${print(path)}`, () => {
-      expect(pathToActiveWhen(dynamicPath)(new URL(path))).toBe(expectTo);
+      expect(pathToActiveWhen(dynamicPath, exactMatch)(new URL(path))).toBe(
+        expectTo
+      );
     });
   });
 }

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -455,9 +455,13 @@ function toDynamicPathValidatorRegex(path, exactMatch) {
     if (index === path.length) {
       if (inDynamic) {
         if (exactMatch) {
+          // Ensure paths that end in a dynamic portion don't match
+          // urls with characters after a slash after the dynamic portion.
           regexStr += "$";
         }
       } else {
+        // For exact matches, expect no more characters. Otherwise, allow
+        // any characters.
         const suffix = exactMatch ? "" : ".*";
 
         regexStr =

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -455,7 +455,7 @@ function toDynamicPathValidatorRegex(path, exactMatch) {
     if (index === path.length) {
       if (inDynamic) {
         if (exactMatch) {
-          // Ensure paths that end in a dynamic portion don't match
+          // Ensure exact match paths that end in a dynamic portion don't match
           // urls with characters after a slash after the dynamic portion.
           regexStr += "$";
         }

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -411,8 +411,8 @@ function sanitizeActiveWhen(activeWhen) {
     activeWhenArray.some((activeWhen) => activeWhen(location));
 }
 
-export function pathToActiveWhen(path) {
-  const regex = toDynamicPathValidatorRegex(path);
+export function pathToActiveWhen(path, exactMatch) {
+  const regex = toDynamicPathValidatorRegex(path, exactMatch);
 
   return (location) => {
     const route = location.href
@@ -423,7 +423,7 @@ export function pathToActiveWhen(path) {
   };
 }
 
-export function toDynamicPathValidatorRegex(path) {
+function toDynamicPathValidatorRegex(path, exactMatch) {
   let lastIndex = 0,
     inDynamic = false,
     regexStr = "^";
@@ -452,12 +452,20 @@ export function toDynamicPathValidatorRegex(path) {
       ? anyCharMaybeTrailingSlashRegex
       : commonStringSubPath;
 
-    if (index === path.length && !inDynamic) {
-      regexStr =
-        // use charAt instead as we could not use es6 method endsWith
-        regexStr.charAt(regexStr.length - 1) === "/"
-          ? `${regexStr}.*$`
-          : `${regexStr}([/#].*)?$`;
+    if (index === path.length) {
+      if (inDynamic) {
+        if (exactMatch) {
+          regexStr += "$";
+        }
+      } else {
+        const suffix = exactMatch ? "" : ".*";
+
+        regexStr =
+          // use charAt instead as we could not use es6 method endsWith
+          regexStr.charAt(regexStr.length - 1) === "/"
+            ? `${regexStr}${suffix}$`
+            : `${regexStr}(/${suffix})?(#.*)?$`;
+      }
     }
 
     inDynamic = !inDynamic;


### PR DESCRIPTION
This will be used for `<route path="/" exact>` within single-spa-layout. See https://github.com/single-spa/single-spa-layout/issues/46