### PR TITLE
Parcel type fixes

### DIFF
--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -4,10 +4,10 @@ declare module "single-spa" {
     [num: number]: any;
   }
 
-  type CustomPropsFn<T extends CustomProps = CustomProps> = (
+  type CustomPropsFn<ExtraProps extends CustomProps = CustomProps> = (
     name: string,
     location: Location
-  ) => T;
+  ) => ExtraProps;
 
   export type AppProps = {
     name: string;
@@ -27,10 +27,10 @@ declare module "single-spa" {
     name?: string;
   } & LifeCycles<ExtraProps>;
 
-  type Parcel = {
+  type Parcel<ExtraProps = CustomProps> = {
     mount(): Promise<null>;
     unmount(): Promise<null>;
-    update?(customProps: CustomProps): Promise<any>;
+    update?(customProps: ExtraProps): Promise<any>;
     getStatus():
       | "NOT_LOADED"
       | "LOADING_SOURCE_CODE"
@@ -50,12 +50,14 @@ declare module "single-spa" {
     unmountPromise: Promise<null>;
   };
 
-  type LifeCycleFn<T> = (config: T & AppProps) => Promise<any>;
-  export type LifeCycles<T = {}> = {
-    bootstrap: LifeCycleFn<T> | Array<LifeCycleFn<T>>;
-    mount: LifeCycleFn<T> | Array<LifeCycleFn<T>>;
-    unmount: LifeCycleFn<T> | Array<LifeCycleFn<T>>;
-    update?: LifeCycleFn<T> | Array<LifeCycleFn<T>>;
+  type LifeCycleFn<ExtraProps> = (
+    config: ExtraProps & AppProps
+  ) => Promise<any>;
+  export type LifeCycles<ExtraProps = {}> = {
+    bootstrap: LifeCycleFn<ExtraProps> | Array<LifeCycleFn<ExtraProps>>;
+    mount: LifeCycleFn<ExtraProps> | Array<LifeCycleFn<ExtraProps>>;
+    unmount: LifeCycleFn<ExtraProps> | Array<LifeCycleFn<ExtraProps>>;
+    update?: LifeCycleFn<ExtraProps> | Array<LifeCycleFn<ExtraProps>>;
   };
 
   export type StartOpts = {
@@ -77,19 +79,19 @@ declare module "single-spa" {
   export function setUnmountMaxTime(time: number, dieOnTimeout?: boolean): void;
   export function setUnloadMaxTime(time: number, dieOnTimeout?: boolean): void;
 
-  type Application<T = {}> =
-    | LifeCycles<T>
-    | ((config: T & AppProps) => Promise<LifeCycles<T>>);
+  type Application<ExtraProps = {}> =
+    | LifeCycles<ExtraProps>
+    | ((config: ExtraProps & AppProps) => Promise<LifeCycles<ExtraProps>>);
 
   type ActivityFn = (location: Location) => boolean;
 
   type Activity = ActivityFn | string | (ActivityFn | string)[];
 
-  export type RegisterApplicationConfig<T extends CustomProps = {}> = {
+  export type RegisterApplicationConfig<ExtraProps extends CustomProps = {}> = {
     name: string;
-    app: Application<T>;
+    app: Application<ExtraProps>;
     activeWhen: Activity;
-    customProps?: T | CustomPropsFn<T>;
+    customProps?: ExtraProps | CustomPropsFn<ExtraProps>;
   };
 
   interface SingleSpaNewAppStatus {
@@ -117,15 +119,15 @@ declare module "single-spa" {
   };
 
   // ./applications/apps.js
-  export function registerApplication<T extends object = {}>(
+  export function registerApplication<ExtraProps extends CustomProps = {}>(
     appName: string,
-    applicationOrLoadingFn: Application<T>,
+    applicationOrLoadingFn: Application<ExtraProps>,
     activityFn: ActivityFn,
-    customProps?: T | CustomPropsFn<T>
+    customProps?: ExtraProps | CustomPropsFn<ExtraProps>
   ): void;
 
-  export function registerApplication<T extends object = {}>(
-    config: RegisterApplicationConfig<T>
+  export function registerApplication<ExtraProps extends CustomProps = {}>(
+    config: RegisterApplicationConfig<ExtraProps>
   ): void;
 
   export function unregisterApplication(appName: string): Promise<any>;
@@ -182,9 +184,9 @@ declare module "single-spa" {
 
   // './parcels/mount-parcel.js'
   export function mountRootParcel<ExtraProps = CustomProps>(
-    parcelConfig: ParcelConfig,
+    parcelConfig: ParcelConfig<ExtraProps>,
     parcelProps: ParcelProps & ExtraProps
-  ): Parcel;
+  ): Parcel<ExtraProps>;
 
   export function pathToActiveWhen(path: string): ActivityFn;
 }

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -18,12 +18,14 @@ declare module "single-spa" {
     ): Parcel;
   };
 
-  export type ParcelConfig =
-    | ParcelConfigObject
-    | (() => Promise<ParcelConfigObject>);
+  export type ParcelConfig<ExtraProps = {}> =
+    | ParcelConfigObject<ExtraProps>
+    | (() => Promise<ParcelConfigObject<ExtraProps>>);
 
   type ParcelProps = { domElement: HTMLElement };
-  type ParcelConfigObject = { name?: string } & LifeCycles;
+  type ParcelConfigObject<ExtraProps = {}> = { name?: string } & LifeCycles<
+    ExtraProps
+  >;
 
   type Parcel = {
     mount(): Promise<null>;
@@ -62,7 +64,6 @@ declare module "single-spa" {
 
   // ./start.js
   export function start(opts?: StartOpts): void;
-  export function isStarted(): boolean;
 
   // ./jquery-support.js
   export function ensureJQuerySupport(jQuery?: any): void;
@@ -180,9 +181,9 @@ declare module "single-spa" {
   export function removeErrorHandler(handler: (error: AppError) => void): void;
 
   // './parcels/mount-parcel.js'
-  export function mountRootParcel(
+  export function mountRootParcel<ExtraProps = {}>(
     parcelConfig: ParcelConfig,
-    parcelProps: ParcelProps & CustomProps
+    parcelProps: ParcelProps & ExtraProps
   ): Parcel;
 
   export function pathToActiveWhen(path: string): ActivityFn;

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -18,14 +18,14 @@ declare module "single-spa" {
     ): Parcel;
   };
 
-  export type ParcelConfig<ExtraProps = {}> =
+  export type ParcelConfig<ExtraProps = CustomProps> =
     | ParcelConfigObject<ExtraProps>
     | (() => Promise<ParcelConfigObject<ExtraProps>>);
 
   type ParcelProps = { domElement: HTMLElement };
-  type ParcelConfigObject<ExtraProps = {}> = { name?: string } & LifeCycles<
-    ExtraProps
-  >;
+  type ParcelConfigObject<ExtraProps = CustomProps> = {
+    name?: string;
+  } & LifeCycles<ExtraProps>;
 
   type Parcel = {
     mount(): Promise<null>;
@@ -181,7 +181,7 @@ declare module "single-spa" {
   export function removeErrorHandler(handler: (error: AppError) => void): void;
 
   // './parcels/mount-parcel.js'
-  export function mountRootParcel<ExtraProps = {}>(
+  export function mountRootParcel<ExtraProps = CustomProps>(
     parcelConfig: ParcelConfig,
     parcelProps: ParcelProps & ExtraProps
   ): Parcel;

--- a/typings/single-spa.test-d.ts
+++ b/typings/single-spa.test-d.ts
@@ -6,8 +6,16 @@ import {
   SingleSpaCustomEventDetail,
   SingleSpaNewAppStatus,
   SingleSpaAppsByNewStatus,
+  Parcel,
+  ParcelConfig,
 } from "single-spa";
 import { expectError, expectType } from "tsd";
+
+const planetsParcel: ParcelConfig<Planets> = {
+  async bootstrap() {},
+  async mount() {},
+  async unmount() {},
+};
 
 const appOrParcel = {
   async bootstrap() {},
@@ -20,7 +28,23 @@ mountRootParcel(appOrParcel, {
   domElement: document.createElement("div"),
 });
 
-expectError(mountRootParcel(appOrParcel, () => {}));
+interface Planets {
+  favoritePlanet: string;
+}
+
+const parcel: Parcel<Planets> = mountRootParcel<Planets>(appOrParcel, {
+  domElement: document.createElement("div"),
+  favoritePlanet: "Mercury",
+});
+if (parcel.update) {
+  parcel.update({
+    favoritePlanet: "Mars",
+  });
+}
+
+expectError(
+  mountRootParcel<Planets>(appOrParcel, () => {})
+);
 
 registerApplication({
   name: "app1",


### PR DESCRIPTION
I found some problems while working on https://github.com/single-spa/single-spa-react/issues/99 - ParcelConfig and Parcel objects didn't have generics, which made it so I couldn't strictly type the single-spa-react `<Parcel />` component.

I have done my very best here to try to make the changes backwards compatible, by having all the newly added generics have default values so that code that uses them without specifying generics will still compile. However, there's a chance that I don't know something about typescript backwards compatibility.

I also renamed the `T` generic everywhere to have a more descriptive name, as I find descriptive names to be easier to understand for generics.