### PR TITLE
Adding optional parameter exactMatch to pathToActiveWhen type definition

### DIFF
--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -188,5 +188,8 @@ declare module "single-spa" {
     parcelProps: ParcelProps & ExtraProps
   ): Parcel<ExtraProps>;
 
-  export function pathToActiveWhen(path: string): ActivityFn;
+  export function pathToActiveWhen(
+    path: string,
+    exactMatch?: boolean
+  ): ActivityFn;
 }

--- a/typings/single-spa.test-d.ts
+++ b/typings/single-spa.test-d.ts
@@ -67,6 +67,9 @@ registerApplication({
 const activeWhen = pathToActiveWhen("/users/:id");
 expectType<boolean>(activeWhen(window.location));
 
+const activeWhenExact = pathToActiveWhen("/users/:id", true);
+expectType<boolean>(activeWhenExact(window.location));
+
 window.addEventListener("single-spa:routing-event", ((
   evt: CustomEvent<SingleSpaCustomEventDetail>
 ) => {


### PR DESCRIPTION
**Bug description**
Type definitions do not match with the [latest changes](https://single-spa.js.org/docs/api/#pathtoactivewhen). Specifically, the next definition

```export function pathToActiveWhen(path: string): ActivityFn;```

should be

```export function pathToActiveWhen(path: string, exactMatch?: boolean): ActivityFn;```

**Important**
I was not able to perform this commit on a regular way since the tests are failing on my side.

I don't know exactly why, tests fail after commit [bfeff3f](https://github.com/single-spa/single-spa/commit/bfeff3f5b5b39ba2e2daebeba2c0584d2301c1b4).

Since I have this problem without making any changes on the code, I understand this is a problem happening only on my side. In any case, GitHub will perform the tests too, so, considering that, and the simplicity of my proposed change, I've forced the commit with a `--no-verify` flag.
