### PR TITLE
chore(dependency): custom-event should be list in dependencies rather than devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
   ],
   "author": "Joel Denning",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "custom-event": "^1.0.1"
+  },
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/eslint-parser": "^7.11.5",
@@ -70,7 +72,6 @@
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "concurrently": "^5.1.0",
     "cross-env": "^7.0.2",
-    "custom-event": "^1.0.1",
     "eslint": "6.8.0",
     "eslint-config-important-stuff": "^1.1.0",
     "eslint-plugin-es5": "^1.5.0",


### PR DESCRIPTION
custom-event package should be list in dependencies as our source code have referenced it directly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/single-spa/single-spa/775)
<!-- Reviewable:end -->
