### PR TITLE
Fix regression with parcel name

### DIFF
--- a/src/parcels/mount-parcel.js
+++ b/src/parcels/mount-parcel.js
@@ -50,6 +50,9 @@ export function mountParcel(config, customProps) {
     );
   }
 
+  const id = parcelCount++;
+  const name = config.name || `parcel-${id}`;
+
   if (typeof customProps !== "object") {
     throw Error(
       formatErrorMessage(
@@ -72,8 +75,6 @@ export function mountParcel(config, customProps) {
       )
     );
   }
-
-  const id = parcelCount++;
 
   const passedConfigLoadingFunction = typeof config === "function";
   const configLoadingFunction = passedConfigLoadingFunction

--- a/src/parcels/mount-parcel.js
+++ b/src/parcels/mount-parcel.js
@@ -51,7 +51,7 @@ export function mountParcel(config, customProps) {
   }
 
   const id = parcelCount++;
-  const name = config.name || `parcel-${id}`;
+  let name = config.name || `parcel-${id}`;
 
   if (typeof customProps !== "object") {
     throw Error(
@@ -154,7 +154,7 @@ export function mountParcel(config, customProps) {
       );
     }
 
-    const name = config.name || `parcel-${id}`;
+    name = config.name || `parcel-${id}`;
 
     if (
       // ES Module objects don't have the object prototype


### PR DESCRIPTION
This fixes a bug caused by https://github.com/single-spa/single-spa/commit/20fb98a8bf5df9da74edf2d7c9b134e50d6466fb#diff-f6a2de459a33bb86856679dc94eae0ec89e16e8856edea2743fd0e3e781c2337 where `name` was not being defined before it was being used.