### PR TITLE
Async navigation cancelation

### DIFF
--- a/spec/apis/navigate-before-patch-history.spec.js
+++ b/spec/apis/navigate-before-patch-history.spec.js
@@ -1,0 +1,22 @@
+import { navigateToUrl } from "../../src/single-spa";
+
+// https://github.com/single-spa/single-spa/pull/826#discussion_r664713545
+describe("singleSpaNavigate() before patchHistoryApi()", () => {
+  it(`doesn't throw an error when a navigation is canceled`, async () => {
+    window.addEventListener(
+      "single-spa:before-routing-event",
+      cancelTheNavigation
+    );
+
+    navigateToUrl("/other-url");
+    await Promise.resolve();
+
+    function cancelTheNavigation(evt) {
+      evt.detail.cancelNavigation();
+      window.removeEventListener(
+        "single-spa:before-routing-event",
+        cancelTheNavigation
+      );
+    }
+  });
+});

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -136,7 +136,11 @@ function createPopStateEvent(state, originalMethodName) {
   return evt;
 }
 
+export let originalReplaceState = null;
+
 if (isInBrowser) {
+  originalReplaceState = window.history.replaceState;
+
   // We will trigger an app change for any routing events.
   window.addEventListener("hashchange", urlReroute);
   window.addEventListener("popstate", urlReroute);
@@ -176,7 +180,7 @@ if (isInBrowser) {
     "pushState"
   );
   window.history.replaceState = patchedUpdateState(
-    window.history.replaceState,
+    originalReplaceState,
     "replaceState"
   );
 

--- a/src/navigation/reroute.js
+++ b/src/navigation/reroute.js
@@ -70,11 +70,10 @@ export function reroute(pendingPromises = [], eventArguments) {
   }
 
   function cancelNavigation(promise) {
-      if (typeof promise?.then === "function") {
-        cancelPromises.push(promise);
-      } else {
-        cancelPromises.push(Promise.resolve(true));
-      }
+    if (typeof promise?.then === "function") {
+      cancelPromises.push(promise);
+    } else {
+      cancelPromises.push(Promise.resolve(true));
     }
   }
 
@@ -115,7 +114,7 @@ export function reroute(pendingPromises = [], eventArguments) {
       );
 
       return Promise.all(cancelPromises).then((cancelValues) => {
-        if (cancelValues.some(v => v)) {
+        if (cancelValues.some((v) => v)) {
           window.dispatchEvent(
             new CustomEvent(
               "single-spa:before-mount-routing-event",
@@ -282,7 +281,6 @@ export function reroute(pendingPromises = [], eventArguments) {
         originalEvent: eventArguments?.[0],
         oldUrl,
         newUrl,
-        navigationIsCanceled,
       },
     };
 

--- a/src/navigation/reroute.js
+++ b/src/navigation/reroute.js
@@ -11,7 +11,7 @@ import {
 } from "../applications/apps.js";
 import {
   callCapturedEventListeners,
-  navigateToUrl,
+  originalReplaceState,
 } from "./navigation-events.js";
 import { toUnloadPromise } from "../lifecycles/unload.js";
 import {
@@ -24,6 +24,7 @@ import {
 } from "../applications/app.helpers.js";
 import { assign } from "../utils/assign.js";
 import { isInBrowser } from "../utils/runtime-environment.js";
+import { formatErrorMessage } from "../applications/app-errors.js";
 
 let appChangeUnderway = false,
   peopleWaitingOnAppChange = [],
@@ -34,7 +35,11 @@ export function triggerAppChange() {
   return reroute();
 }
 
-export function reroute(pendingPromises = [], eventArguments) {
+export function reroute(
+  pendingPromises = [],
+  eventArguments,
+  silentNavigation = false
+) {
   if (appChangeUnderway) {
     return new Promise((resolve, reject) => {
       peopleWaitingOnAppChange.push({
@@ -69,12 +74,26 @@ export function reroute(pendingPromises = [], eventArguments) {
     return loadApps();
   }
 
-  function cancelNavigation(promise) {
-    if (typeof promise?.then === "function") {
-      cancelPromises.push(promise);
-    } else {
-      cancelPromises.push(Promise.resolve(true));
-    }
+  function cancelNavigation(val = true) {
+    const promise =
+      typeof val?.then === "function" ? val : Promise.resolve(val);
+    cancelPromises.push(
+      promise.catch((err) => {
+        console.warn(
+          Error(
+            formatErrorMessage(
+              42,
+              __DEV__ &&
+                `single-spa: A cancelNavigation promise rejected with the following value: ${err}`
+            )
+          )
+        );
+        console.warn(err);
+
+        // Interpret a Promise rejection to mean that the navigation should not be canceled
+        return false;
+      })
+    );
   }
 
   function loadApps() {
@@ -97,33 +116,38 @@ export function reroute(pendingPromises = [], eventArguments) {
   function performAppChanges() {
     return Promise.resolve().then(() => {
       // https://github.com/single-spa/single-spa/issues/545
-      window.dispatchEvent(
-        new CustomEvent(
-          appsThatChanged.length === 0
-            ? "single-spa:before-no-app-change"
-            : "single-spa:before-app-change",
-          getCustomEventDetail(true)
-        )
+      fireSingleSpaEvent(
+        appsThatChanged.length === 0
+          ? "before-no-app-change"
+          : "before-app-change",
+        getCustomEventDetail(true)
       );
 
-      window.dispatchEvent(
-        new CustomEvent(
-          "single-spa:before-routing-event",
-          getCustomEventDetail(true, { cancelNavigation })
-        )
+      fireSingleSpaEvent(
+        "before-routing-event",
+        getCustomEventDetail(true, { cancelNavigation })
       );
 
       return Promise.all(cancelPromises).then((cancelValues) => {
-        if (cancelValues.some((v) => v)) {
-          window.dispatchEvent(
-            new CustomEvent(
-              "single-spa:before-mount-routing-event",
-              getCustomEventDetail(true)
-            )
+        const navigationIsCanceled = cancelValues.some((v) => v);
+
+        if (navigationIsCanceled) {
+          // Change url back to old url, without triggering the normal single-spa reroute
+          originalReplaceState.call(
+            window.history,
+            history.state,
+            "",
+            oldUrl.substring(location.origin.length)
           );
-          finishUpAndReturn();
-          navigateToUrl(oldUrl);
-          return;
+
+          // Single-spa's internal tracking of current url needs to be updated after the url change above
+          currentUrl = location.href;
+
+          // necessary for the reroute function to know that the current reroute is finished
+          appChangeUnderway = false;
+
+          // Tell single-spa to reroute again, this time with the url set to the old URL
+          return reroute(peopleWaitingOnAppChange, eventArguments, true);
         }
 
         const unloadPromises = appsToUnload.map(toUnloadPromise);
@@ -137,11 +161,9 @@ export function reroute(pendingPromises = [], eventArguments) {
         const unmountAllPromise = Promise.all(allUnmountPromises);
 
         unmountAllPromise.then(() => {
-          window.dispatchEvent(
-            new CustomEvent(
-              "single-spa:before-mount-routing-event",
-              getCustomEventDetail(true)
-            )
+          fireSingleSpaEvent(
+            "before-mount-routing-event",
+            getCustomEventDetail(true)
           );
         });
 
@@ -192,15 +214,9 @@ export function reroute(pendingPromises = [], eventArguments) {
 
     try {
       const appChangeEventName =
-        appsThatChanged.length === 0
-          ? "single-spa:no-app-change"
-          : "single-spa:app-change";
-      window.dispatchEvent(
-        new CustomEvent(appChangeEventName, getCustomEventDetail())
-      );
-      window.dispatchEvent(
-        new CustomEvent("single-spa:routing-event", getCustomEventDetail())
-      );
+        appsThatChanged.length === 0 ? "no-app-change" : "app-change";
+      fireSingleSpaEvent(appChangeEventName, getCustomEventDetail());
+      fireSingleSpaEvent("routing-event", getCustomEventDetail());
     } catch (err) {
       /* We use a setTimeout because if someone else's event handler throws an error, single-spa
        * needs to carry on. If a listener to the event throws an error, it's their own fault, not
@@ -237,11 +253,15 @@ export function reroute(pendingPromises = [], eventArguments) {
    * single-spa, which means queued ones first and then the most recent one.
    */
   function callAllEventListeners() {
-    pendingPromises.forEach((pendingPromise) => {
-      callCapturedEventListeners(pendingPromise.eventArguments);
-    });
+    // During silent navigation (when navigation was canceled and we're going back to the old URL),
+    // we should not fire any popstate / hashchange events
+    if (!silentNavigation) {
+      pendingPromises.forEach((pendingPromise) => {
+        callCapturedEventListeners(pendingPromise.eventArguments);
+      });
 
-    callCapturedEventListeners(eventArguments);
+      callCapturedEventListeners(eventArguments);
+    }
   }
 
   function getCustomEventDetail(isBeforeChanges = false, extraProperties) {
@@ -297,6 +317,16 @@ export function reroute(pendingPromises = [], eventArguments) {
       const statusArr = (appsByNewStatus[status] =
         appsByNewStatus[status] || []);
       statusArr.push(appName);
+    }
+  }
+
+  function fireSingleSpaEvent(name, eventProperties) {
+    // During silent navigation (caused by navigation cancelation), we should not
+    // fire any single-spa events
+    if (!silentNavigation) {
+      window.dispatchEvent(
+        new CustomEvent(`single-spa:${name}`, eventProperties)
+      );
     }
   }
 }


### PR DESCRIPTION
Resolves #670. I started with the code from @cjpearson in https://github.com/single-spa/single-spa/pull/689 and finished out the implementation, including adding tests.

This is a breaking change, as single-spa events are no longer fired for the reroute caused by cancelation, and also the `navigationIsCanceled` boolean is removed from all custom event detail objects (since it's never true anymore due to events no longer being fired after cancelation occurs). Since it's breaking, I have it merging into the 6.0 branch rather than the master branch.