### PR TITLE
Expose patchHistoryApi. Improve DX for parcel-only usage.

### DIFF
--- a/spec/apis/multiple-instances.spec.js
+++ b/spec/apis/multiple-instances.spec.js
@@ -15,7 +15,7 @@ describe(`multiple instances of single-spa`, () => {
 
     expect(consoleWarnSpy).not.toHaveBeenCalled();
 
-    await import("single-spa");
+    const singleSpa = await import("single-spa");
 
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       "single-spa minified message #41: single-spa has been loaded twice on the page. This can result in unexpected behavior. See https://single-spa.js.org/error/?code=41"

--- a/spec/apis/multiple-instances.spec.js
+++ b/spec/apis/multiple-instances.spec.js
@@ -15,7 +15,7 @@ describe(`multiple instances of single-spa`, () => {
 
     expect(consoleWarnSpy).not.toHaveBeenCalled();
 
-    const singleSpa = await import("single-spa");
+    await import("single-spa");
 
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       "single-spa minified message #41: single-spa has been loaded twice on the page. This can result in unexpected behavior. See https://single-spa.js.org/error/?code=41"

--- a/spec/apis/patch-history-api.spec.js
+++ b/spec/apis/patch-history-api.spec.js
@@ -1,0 +1,42 @@
+import { navigateToUrl, patchHistoryApi } from "../../src/single-spa";
+
+describe("patchHistoryApi", () => {
+  it(`patches the history api only once`, async () => {
+    navigateToUrl("/");
+    let numPopstates = 0;
+
+    window.addEventListener("popstate", popstateListener);
+
+    navigateToUrl("/a");
+    await tick();
+    expect(numPopstates).toEqual(0);
+
+    history.pushState(history.state, "", "/");
+    await tick();
+    expect(numPopstates).toEqual(0);
+
+    patchHistoryApi();
+
+    navigateToUrl("/b");
+    await tick();
+    expect(numPopstates).toEqual(1);
+
+    history.pushState(history.state, "", "/c");
+    await tick();
+    expect(numPopstates).toEqual(2);
+
+    expect(patchHistoryApi).toThrowError(
+      "was called after the history api was already patched"
+    );
+
+    function popstateListener() {
+      numPopstates++;
+    }
+  });
+});
+
+function tick() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 10);
+  });
+}

--- a/spec/apis/patch-history-api.spec.js
+++ b/spec/apis/patch-history-api.spec.js
@@ -25,6 +25,8 @@ describe("patchHistoryApi", () => {
     await tick();
     expect(numPopstates).toEqual(2);
 
+    window.removeEventListener("popstate", popstateListener);
+
     expect(patchHistoryApi).toThrowError(
       "was called after the history api was already patched"
     );

--- a/spec/apis/start-api.spec.js
+++ b/spec/apis/start-api.spec.js
@@ -1,0 +1,26 @@
+import { registerApplication } from "../../src/single-spa";
+
+describe("start()", () => {
+  beforeAll(jest.useFakeTimers);
+  afterAll(jest.useRealTimers);
+
+  it(`does not throw an error before start() is called`, async () => {
+    jest.spyOn(console, "warn");
+
+    jest.advanceTimersByTime(5000);
+    expect(console.warn).not.toHaveBeenCalled();
+
+    registerApplication({
+      name: "app1",
+      app: {
+        async mount() {},
+        async unmount() {},
+      },
+      activeWhen: "/",
+    });
+    jest.advanceTimersByTime(5000);
+
+    expect(console.warn).toHaveBeenCalled();
+    console.warn.mockRestore();
+  });
+});

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -22,6 +22,7 @@ import {
 import { formatErrorMessage } from "./app-errors.js";
 import { isInBrowser } from "../utils/runtime-environment.js";
 import { assign } from "../utils/assign";
+import { isStarted } from "../start.js";
 
 const apps = [];
 
@@ -88,6 +89,8 @@ export function getAppStatus(appName) {
   return app ? app.status : null;
 }
 
+let startWarningInitialized = false;
+
 export function registerApplication(
   appNameOrConfig,
   appOrLoadApp,
@@ -100,6 +103,22 @@ export function registerApplication(
     activeWhen,
     customProps
   );
+
+  if (!isStarted() && !startWarningInitialized) {
+    startWarningInitialized = true;
+
+    setTimeout(() => {
+      if (!isStarted()) {
+        console.warn(
+          formatErrorMessage(
+            1,
+            __DEV__ &&
+              `singleSpa.start() has not been called, 5000ms after single-spa was loaded. Before start() is called, apps can be declared and loaded, but not bootstrapped or mounted.`
+          )
+        );
+      }
+    }, 5000);
+  }
 
   if (getAppNames().indexOf(registration.name) !== -1)
     throw Error(

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -82,10 +82,6 @@ export function callCapturedEventListeners(eventArguments) {
 
 let urlRerouteOnly;
 
-export function setUrlRerouteOnly(val) {
-  urlRerouteOnly = val;
-}
-
 function urlReroute() {
   reroute([], arguments);
 }
@@ -145,7 +141,7 @@ export function patchHistoryApi(opts) {
   }
 
   if (opts) {
-    setUrlRerouteOnly(opts.urlRerouteOnly);
+    urlRerouteOnly = opts.urlRerouteOnly;
   }
 
   historyApiIsPatched = true;

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -2,7 +2,6 @@ import { reroute } from "./reroute.js";
 import { find } from "../utils/find.js";
 import { formatErrorMessage } from "../applications/app-errors.js";
 import { isInBrowser } from "../utils/runtime-environment.js";
-import { isStarted } from "../start.js";
 
 /* We capture navigation event listeners so that we can make sure
  * that application navigation listeners are not called until
@@ -98,19 +97,12 @@ function patchedUpdateState(updateState, methodName) {
     const urlAfter = window.location.href;
 
     if (!urlRerouteOnly || urlBefore !== urlAfter) {
-      if (isStarted()) {
-        // fire an artificial popstate event once single-spa is started,
-        // so that single-spa applications know about routing that
-        // occurs in a different application
-        window.dispatchEvent(
-          createPopStateEvent(window.history.state, methodName)
-        );
-      } else {
-        // do not fire an artificial popstate event before single-spa is started,
-        // since no single-spa applications need to know about routing events
-        // outside of their own router.
-        reroute([]);
-      }
+      // fire an artificial popstate event so that
+      // single-spa applications know about routing that
+      // occurs in a different application
+      window.dispatchEvent(
+        createPopStateEvent(window.history.state, methodName)
+      );
     }
 
     return result;
@@ -136,7 +128,24 @@ function createPopStateEvent(state, originalMethodName) {
   return evt;
 }
 
-if (isInBrowser) {
+let historyApiIsPatched = false;
+
+// We patch the history API so single-spa is notified of all calls to pushState/replaceState.
+// We patch addEventListener/removeEventListener so we can capture all popstate/hashchange event listeners,
+// and delay calling them until single-spa has finished mounting/unmounting applications
+export function patchHistoryApi() {
+  if (historyApiIsPatched) {
+    throw Error(
+      formatErrorMessage(
+        43,
+        __DEV__ &&
+          `single-spa: patchHistoryApi() was called after the history api was already patched.`
+      )
+    );
+  }
+
+  historyApiIsPatched = true;
+
   // We will trigger an app change for any routing events.
   window.addEventListener("hashchange", urlReroute);
   window.addEventListener("popstate", urlReroute);
@@ -179,7 +188,13 @@ if (isInBrowser) {
     window.history.replaceState,
     "replaceState"
   );
+}
 
+// Detect if single-spa has already been loaded on the page.
+// If so, warn because this can result in lots of problems, including
+// lots of extraneous popstate events and unexpected results for
+// apis like getAppNames().
+if (isInBrowser) {
   if (window.singleSpaNavigate) {
     console.warn(
       formatErrorMessage(

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -133,7 +133,7 @@ let historyApiIsPatched = false;
 // We patch the history API so single-spa is notified of all calls to pushState/replaceState.
 // We patch addEventListener/removeEventListener so we can capture all popstate/hashchange event listeners,
 // and delay calling them until single-spa has finished mounting/unmounting applications
-export function patchHistoryApi() {
+export function patchHistoryApi(opts) {
   if (historyApiIsPatched) {
     throw Error(
       formatErrorMessage(
@@ -142,6 +142,11 @@ export function patchHistoryApi() {
           `single-spa: patchHistoryApi() was called after the history api was already patched.`
       )
     );
+  }
+
+  if (opts) {
+    setUrlRerouteOnly(opts.urlRerouteOnly);
+    console.log("urlRerouteOnly", urlRerouteOnly);
   }
 
   historyApiIsPatched = true;

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -146,7 +146,6 @@ export function patchHistoryApi(opts) {
 
   if (opts) {
     setUrlRerouteOnly(opts.urlRerouteOnly);
-    console.log("urlRerouteOnly", urlRerouteOnly);
   }
 
   historyApiIsPatched = true;

--- a/src/single-spa.js
+++ b/src/single-spa.js
@@ -16,7 +16,10 @@ export {
   getAppNames,
   pathToActiveWhen,
 } from "./applications/apps.js";
-export { navigateToUrl } from "./navigation/navigation-events.js";
+export {
+  navigateToUrl,
+  patchHistoryApi,
+} from "./navigation/navigation-events.js";
 export { triggerAppChange } from "./navigation/reroute.js";
 export {
   addErrorHandler,

--- a/src/start.js
+++ b/src/start.js
@@ -10,8 +10,8 @@ let started = false;
 export function start(opts) {
   started = true;
   if (isInBrowser) {
-    reroute();
     patchHistoryApi(opts);
+    reroute();
   }
 }
 

--- a/src/start.js
+++ b/src/start.js
@@ -1,8 +1,5 @@
 import { reroute } from "./navigation/reroute.js";
-import {
-  patchHistoryApi,
-  setUrlRerouteOnly,
-} from "./navigation/navigation-events.js";
+import { patchHistoryApi } from "./navigation/navigation-events.js";
 import { isInBrowser } from "./utils/runtime-environment.js";
 
 let started = false;

--- a/src/start.js
+++ b/src/start.js
@@ -9,12 +9,9 @@ let started = false;
 
 export function start(opts) {
   started = true;
-  if (opts && opts.urlRerouteOnly) {
-    setUrlRerouteOnly(opts.urlRerouteOnly);
-  }
   if (isInBrowser) {
     reroute();
-    patchHistoryApi();
+    patchHistoryApi(opts);
   }
 }
 

--- a/src/start.js
+++ b/src/start.js
@@ -18,10 +18,6 @@ export function start(opts) {
   }
 }
 
-export function stop() {
-  started = false;
-}
-
 export function isStarted() {
   return started;
 }

--- a/src/start.js
+++ b/src/start.js
@@ -1,6 +1,8 @@
 import { reroute } from "./navigation/reroute.js";
-import { formatErrorMessage } from "./applications/app-errors.js";
-import { setUrlRerouteOnly } from "./navigation/navigation-events.js";
+import {
+  patchHistoryApi,
+  setUrlRerouteOnly,
+} from "./navigation/navigation-events.js";
 import { isInBrowser } from "./utils/runtime-environment.js";
 
 let started = false;
@@ -12,23 +14,14 @@ export function start(opts) {
   }
   if (isInBrowser) {
     reroute();
+    patchHistoryApi();
   }
+}
+
+export function stop() {
+  started = false;
 }
 
 export function isStarted() {
   return started;
-}
-
-if (isInBrowser) {
-  setTimeout(() => {
-    if (!started) {
-      console.warn(
-        formatErrorMessage(
-          1,
-          __DEV__ &&
-            `singleSpa.start() has not been called, 5000ms after single-spa was loaded. Before start() is called, apps can be declared and loaded, but not bootstrapped or mounted.`
-        )
-      );
-    }
-  }, 5000);
 }

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -192,4 +192,6 @@ declare module "single-spa" {
     path: string,
     exactMatch?: boolean
   ): ActivityFn;
+
+  export function patchHistoryApi(opts?: StartOpts): void;
 }

--- a/typings/single-spa.test-d.ts
+++ b/typings/single-spa.test-d.ts
@@ -8,6 +8,7 @@ import {
   SingleSpaAppsByNewStatus,
   Parcel,
   ParcelConfig,
+  patchHistoryApi,
 } from "single-spa";
 import { expectError, expectType } from "tsd";
 
@@ -83,3 +84,20 @@ window.addEventListener("single-spa:routing-event", ((
   expectType<boolean>(evt.detail.navigationIsCanceled);
   expectType<(() => void) | undefined>(evt.detail.cancelNavigation);
 }) as EventListener);
+
+expectType<void>(patchHistoryApi());
+expectType<void>(
+  patchHistoryApi({
+    urlRerouteOnly: false,
+  })
+);
+expectType<void>(
+  patchHistoryApi({
+    urlRerouteOnly: true,
+  })
+);
+expectError<void>(
+  patchHistoryApi({
+    random: true,
+  })
+);


### PR DESCRIPTION
Resolves #816

This implements all three of the proposals in #816. It makes things easier for those using single-spa history patching but not using single-spa applications. This PR's base branch is 6.0 because it contains breaking changes.

- (Breaking) Delay patching history api until start() is called.
- (Breaking) Remove start() warning when only using parcels.
- (Feature) Expose patchHistoryApi.