### PR TITLE
Ensure all reroute promises resolve during cancelation.

### DIFF
--- a/.github/workflows/file-size-impact.yml
+++ b/.github/workflows/file-size-impact.yml
@@ -14,15 +14,18 @@ jobs:
       - name: Setup git
         uses: actions/checkout@v2
       - name: Setup node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - name: npm install
-        run: npm install
-      - name: npm run build
-        run: npm run build
-      - name: npm install jsenv-file-size
-        run: npm install --prefix ./.github/workflows/file-size-impact/
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.9.1
+      - name: pnpm install
+        run: pnpm install
+      - name: pnpm run build
+        run: pnpm run build
+      - name: pnpm install jsenv-file-size
+        run: pnpm install --prefix ./.github/workflows/file-size-impact/
       - name: Report file size impact
         run: node ./.github/workflows/file-size-impact/report-file-size-impact.js
         env:

--- a/spec/apis/single-spa-events-api.spec.js
+++ b/spec/apis/single-spa-events-api.spec.js
@@ -614,8 +614,15 @@ describe(`events api :`, () => {
         cancelTheNavigation
       );
 
+      let cancelationFinished,
+        cancelationFinishedPromise = new Promise(
+          (r) => (cancelationFinished = r)
+        );
+
+      console.log("navigating");
       singleSpa.navigateToUrl("/app1");
-      await singleSpa.triggerAppChange();
+
+      await cancelationFinishedPromise;
 
       window.removeEventListener(
         "single-spa:before-routing-event",
@@ -638,6 +645,10 @@ describe(`events api :`, () => {
         cancelTheNavigation
       );
 
+      // Give time for single-spa to actually cancel the navigation
+      await tick();
+
+      // Cancelation causes two reroutes, and therefore two before-no-app-change and two before-routing-events
       expect(preCancelation).toEqual([
         "single-spa:before-no-app-change",
         "single-spa:before-routing-event",
@@ -658,6 +669,7 @@ describe(`events api :`, () => {
         expect(new URL(evt.detail.newUrl).pathname).toEqual("/app1");
         evt.detail.cancelNavigation();
         cancelationStarted = true;
+        cancelationFinished();
       }
     });
 
@@ -813,3 +825,7 @@ describe(`events api :`, () => {
     }
   });
 });
+
+function tick() {
+  return new Promise((r) => setTimeout(r));
+}

--- a/spec/apis/single-spa-events-api.spec.js
+++ b/spec/apis/single-spa-events-api.spec.js
@@ -150,7 +150,6 @@ describe(`events api :`, () => {
       await finishPromise;
 
       function errHandler(err) {
-        console.log("errHandler");
         counterFn();
         console.error(err);
         doneIfAllListenerHadBeenInvoked();
@@ -619,7 +618,6 @@ describe(`events api :`, () => {
           (r) => (cancelationFinished = r)
         );
 
-      console.log("navigating");
       singleSpa.navigateToUrl("/app1");
 
       await cancelationFinishedPromise;

--- a/src/navigation/reroute.js
+++ b/src/navigation/reroute.js
@@ -143,7 +143,7 @@ export function reroute(
           appChangeUnderway = false;
 
           // Tell single-spa to reroute again, this time with the url set to the old URL
-          return reroute(peopleWaitingOnAppChange, eventArguments, true);
+          return reroute(pendingPromises, eventArguments, true);
         }
 
         const unloadPromises = appsToUnload.map(toUnloadPromise);


### PR DESCRIPTION
I discovered in https://github.com/single-spa/single-spa-layout/pull/143 that in 6.0.0-beta.0 that `triggerAppChange()` sometimes never resolves due to the bug fixed here. See https://github.com/single-spa/single-spa-layout/actions/runs/1016317472 for the specific failure.

Fixing the bug required changing the tests a bit, but I was able to keep the assertions the same.