### PR TITLE
Implement profiler for lifecycle events.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,8 @@
     "node": true
   },
   "globals": {
-    "__DEV__": true
+    "__DEV__": true,
+    "__PROFILE__": true
   },
   "plugins": ["es5"],
   "rules": {

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.4"
+          node-version: "16.9.1"
       - uses: pnpm/action-setup@v2.0.1
         with:
           version: 6.15.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: "16.4"
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.11.5
+          version: 6.15.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm test

--- a/.github/workflows/file-size-impact.yml
+++ b/.github/workflows/file-size-impact.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: pnpm/action-setup@v2.0.1
         with:
           version: 6.15.0
-      - name: pnpm install --frozen-lockfile
-        run: pnpm install
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: pnpm run build
         run: pnpm run build
       - name: pnpm install jsenv-file-size

--- a/.github/workflows/file-size-impact.yml
+++ b/.github/workflows/file-size-impact.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [13.12.0]
+        node: [16.4]
     runs-on: ${{ matrix.os }}
     name: report file size impact
     steps:
@@ -19,8 +19,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.9.1
-      - name: pnpm install
+          version: 6.15.0
+      - name: pnpm install --frozen-lockfile
         run: pnpm install
       - name: pnpm run build
         run: pnpm run build

--- a/.github/workflows/file-size-impact.yml
+++ b/.github/workflows/file-size-impact.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16.4]
+        node: [16.9.1]
     runs-on: ${{ matrix.os }}
     name: report file size impact
     steps:

--- a/jest-browser.config.js
+++ b/jest-browser.config.js
@@ -6,5 +6,6 @@ export default {
   globals: {
     __SINGLE_SPA_DEVTOOLS__: {},
     __DEV__: true,
+    __PROFILE__: true,
   },
 };

--- a/jest-node.config.js
+++ b/jest-node.config.js
@@ -7,5 +7,6 @@ export default {
   globals: {
     __SINGLE_SPA_DEVTOOLS__: {},
     __DEV__: true,
+    __PROFILE__: true,
   },
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,7 @@ const useAnalyzer = process.env.ANALYZER === "analyzer";
 const replaceOpts = {
   "process.env.BABEL_ENV": null,
   __DEV__: !isProduction,
+  __PROFILE__: !isProduction,
   preventAssignment: true,
 };
 
@@ -31,7 +32,7 @@ const terserOpts = {
 
 export default (async () => [
   {
-    input: "./src/single-spa.js",
+    input: `./src/single-spa${isProduction ? "" : ".profile"}.js`,
     output: [
       {
         file: `./lib/es5/umd/single-spa${isProduction ? ".min" : ".dev"}.cjs`,
@@ -63,7 +64,7 @@ export default (async () => [
     ],
   },
   {
-    input: "./src/single-spa.js",
+    input: `./src/single-spa${isProduction ? "" : ".profile"}.js`,
     output: [
       {
         file: `./lib/es2015/umd/single-spa${

--- a/spec/apps/profiler-basic/profiler-basic.spec.js
+++ b/spec/apps/profiler-basic/profiler-basic.spec.js
@@ -1,0 +1,248 @@
+import * as singleSpa from "single-spa";
+import {
+  clearProfilerData,
+  getProfilerData,
+} from "../../../src/devtools/profiler.js";
+
+describe(`profiler basics`, () => {
+  let app,
+    shouldMount = false,
+    loadApp;
+
+  beforeAll(() => {
+    singleSpa.start();
+  });
+
+  beforeEach(() => {
+    app = {
+      bootstrap: jest.fn(() => Promise.resolve()),
+      mount: jest.fn(() => Promise.resolve()),
+      unmount: jest.fn(() => Promise.resolve()),
+      unload: jest.fn(() => Promise.resolve()),
+    };
+
+    loadApp = jest.fn(() => Promise.resolve(app));
+
+    singleSpa.registerApplication({
+      name: "profiler-basics",
+      app: loadApp,
+      activeWhen: () => shouldMount,
+    });
+    shouldMount = false;
+  });
+
+  afterEach(async () => {
+    shouldMount = false;
+    await singleSpa.unloadApplication("profiler-basics", {
+      waitForUnmount: false,
+    });
+    singleSpa.unregisterApplication("profiler-basics");
+    await singleSpa.triggerAppChange();
+    clearProfilerData();
+  });
+
+  it(`captures load profile events`, async () => {
+    const loadProfilesBefore = getProfilerEventsByKind("load");
+    expect(loadProfilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.getAppStatus("profiler-basics")).toEqual(
+      singleSpa.MOUNTED
+    );
+    const loadProfilesAfter = getProfilerEventsByKind("load");
+
+    expect(loadProfilesAfter.length).toBe(1);
+    expect(loadProfilesAfter[0].operationSucceeded).toBe(true);
+    expect(Number.isInteger(loadProfilesAfter[0].start)).toBe(true);
+    expect(Number.isInteger(loadProfilesAfter[0].end)).toBe(true);
+  });
+
+  it(`captures load error profile events`, async () => {
+    loadApp.mockImplementationOnce(() =>
+      Promise.reject(Error("Failed to load"))
+    );
+
+    const loadProfilesBefore = getProfilerEventsByKind("load");
+    expect(loadProfilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.getAppStatus("profiler-basics")).toEqual(
+      singleSpa.LOAD_ERROR
+    );
+    const loadProfilesAfter = getProfilerEventsByKind("load");
+
+    expect(loadProfilesAfter.length).toBe(1);
+    expect(loadProfilesAfter[0].operationSucceeded).toBe(false);
+  });
+
+  it(`captures bootstrap profile events`, async () => {
+    const profilesBefore = getProfilerEventsByKind("bootstrap");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.checkActivityFunctions()).toContain("profiler-basics");
+    expect(singleSpa.getAppStatus("profiler-basics")).toEqual(
+      singleSpa.MOUNTED
+    );
+    const profilesAfter = getProfilerEventsByKind("bootstrap");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(true);
+  });
+
+  it(`captures bootstrap error profile events`, async () => {
+    app.bootstrap.mockImplementationOnce(() =>
+      Promise.reject(Error("Bootstrap err"))
+    );
+
+    const profilesBefore = getProfilerEventsByKind("bootstrap");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.checkActivityFunctions()).toContain("profiler-basics");
+    expect(singleSpa.getAppStatus("profiler-basics")).toEqual(
+      singleSpa.SKIP_BECAUSE_BROKEN
+    );
+    const profilesAfter = getProfilerEventsByKind("bootstrap");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(false);
+  });
+
+  it(`captures mount profile events`, async () => {
+    const profilesBefore = getProfilerEventsByKind("mount");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.checkActivityFunctions()).toContain("profiler-basics");
+    expect(singleSpa.getAppStatus("profiler-basics")).toEqual(
+      singleSpa.MOUNTED
+    );
+    const profilesAfter = getProfilerEventsByKind("mount");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(true);
+  });
+
+  it(`captures mount error profile events`, async () => {
+    app.mount.mockImplementationOnce(() => Promise.reject(Error("Mount err")));
+
+    const profilesBefore = getProfilerEventsByKind("mount");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.checkActivityFunctions()).toContain("profiler-basics");
+    expect(singleSpa.getAppStatus("profiler-basics")).toEqual(
+      singleSpa.SKIP_BECAUSE_BROKEN
+    );
+    const profilesAfter = getProfilerEventsByKind("mount");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(false);
+  });
+
+  it(`captures unmount profile events`, async () => {
+    const profilesBefore = getProfilerEventsByKind("unmount");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    shouldMount = false;
+    await singleSpa.triggerAppChange();
+
+    const profilesAfter = getProfilerEventsByKind("unmount");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(true);
+  });
+
+  it(`captures unmount error profile events`, async () => {
+    app.unmount.mockImplementationOnce(() =>
+      Promise.reject(Error("Mount errr"))
+    );
+    const profilesBefore = getProfilerEventsByKind("unmount");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    shouldMount = false;
+    await singleSpa.triggerAppChange();
+
+    expect(singleSpa.getAppStatus("profiler-basics")).toBe(
+      singleSpa.SKIP_BECAUSE_BROKEN
+    );
+
+    const profilesAfter = getProfilerEventsByKind("unmount");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(false);
+  });
+
+  it(`captures unload profile events`, async () => {
+    const profilesBefore = getProfilerEventsByKind("unload");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    shouldMount = false;
+    await singleSpa.unloadApplication("profiler-basics", {
+      waitForUnmount: false,
+    });
+    await singleSpa.triggerAppChange();
+    await singleSpa.triggerAppChange();
+    expect(singleSpa.getAppStatus("profiler-basics")).toEqual(
+      singleSpa.NOT_LOADED
+    );
+
+    const profilesAfter = getProfilerEventsByKind("unload");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(true);
+  });
+
+  it(`captures unloadErr error profile events`, async () => {
+    app.unload.mockImplementationOnce(() =>
+      Promise.reject(Error("Unload errr"))
+    );
+    const profilesBefore = getProfilerEventsByKind("unload");
+    expect(profilesBefore.length).toBe(0);
+
+    shouldMount = true;
+    await singleSpa.triggerAppChange();
+    shouldMount = false;
+    await singleSpa.triggerAppChange();
+    clearProfilerData();
+    try {
+      await singleSpa.unloadApplication("profiler-basics", {
+        waitForUnmount: false,
+      });
+      fail("Expected unload err");
+    } catch (err) {}
+
+    await singleSpa.triggerAppChange();
+
+    expect(singleSpa.getAppStatus("profiler-basics")).toBe(
+      singleSpa.SKIP_BECAUSE_BROKEN
+    );
+
+    const profilesAfter = getProfilerEventsByKind("unload");
+
+    expect(profilesAfter.length).toBe(1);
+    expect(profilesAfter[0].operationSucceeded).toBe(false);
+  });
+});
+
+function getProfilerEventsByKind(kind) {
+  return getProfilerData().filter(
+    (d) =>
+      d.type === "application" &&
+      d.name === "profiler-basics" &&
+      d.kind === kind
+  );
+}

--- a/spec/apps/profiler-basic/profiler-basic.spec.js
+++ b/spec/apps/profiler-basic/profiler-basic.spec.js
@@ -54,8 +54,8 @@ describe(`profiler basics`, () => {
 
     expect(loadProfilesAfter.length).toBe(1);
     expect(loadProfilesAfter[0].operationSucceeded).toBe(true);
-    expect(Number.isInteger(loadProfilesAfter[0].start)).toBe(true);
-    expect(Number.isInteger(loadProfilesAfter[0].end)).toBe(true);
+    expect(!Number.isNaN(loadProfilesAfter[0].start)).toBe(true);
+    expect(!Number.isNaN(loadProfilesAfter[0].end)).toBe(true);
   });
 
   it(`captures load error profile events`, async () => {

--- a/src/devtools/profiler-api.js
+++ b/src/devtools/profiler-api.js
@@ -1,0 +1,1 @@
+export { getProfilerData } from "./profiler.js";

--- a/src/devtools/profiler.js
+++ b/src/devtools/profiler.js
@@ -1,0 +1,36 @@
+let profileEntries = [];
+
+export function getProfilerData() {
+  return profileEntries;
+}
+
+/**
+ *
+ * @type {'application' | 'parcel' | 'routing'} ProfileType
+ *
+ * @param {ProfileType} type
+ * @param {String} name
+ * @param {number} start
+ * @param {number} end
+ */
+export function addProfileEntry(
+  type,
+  name,
+  kind,
+  start,
+  end,
+  operationSucceeded
+) {
+  profileEntries.push({
+    type,
+    name,
+    start,
+    end,
+    kind,
+    operationSucceeded,
+  });
+}
+
+export function clearProfilerData() {
+  profileEntries = [];
+}

--- a/src/lifecycles/bootstrap.js
+++ b/src/lifecycles/bootstrap.js
@@ -18,7 +18,7 @@ export function toBootstrapPromise(appOrParcel, hardFail) {
     }
 
     if (__PROFILE__) {
-      startTime = Date.now();
+      startTime = performance.now();
     }
 
     appOrParcel.status = BOOTSTRAPPING;
@@ -37,7 +37,7 @@ export function toBootstrapPromise(appOrParcel, hardFail) {
             toName(appOrParcel),
             "bootstrap",
             startTime,
-            Date.now(),
+            performance.now(),
             false
           );
         }
@@ -60,7 +60,7 @@ export function toBootstrapPromise(appOrParcel, hardFail) {
         toName(appOrParcel),
         "bootstrap",
         startTime,
-        Date.now(),
+        performance.now(),
         true
       );
     }

--- a/src/lifecycles/bootstrap.js
+++ b/src/lifecycles/bootstrap.js
@@ -3,14 +3,22 @@ import {
   BOOTSTRAPPING,
   NOT_MOUNTED,
   SKIP_BECAUSE_BROKEN,
+  toName,
 } from "../applications/app.helpers.js";
 import { reasonableTime } from "../applications/timeouts.js";
 import { handleAppError, transformErr } from "../applications/app-errors.js";
+import { addProfileEntry } from "../devtools/profiler.js";
 
 export function toBootstrapPromise(appOrParcel, hardFail) {
+  let startTime;
+
   return Promise.resolve().then(() => {
     if (appOrParcel.status !== NOT_BOOTSTRAPPED) {
       return appOrParcel;
+    }
+
+    if (__PROFILE__) {
+      startTime = Date.now();
     }
 
     appOrParcel.status = BOOTSTRAPPING;
@@ -23,6 +31,17 @@ export function toBootstrapPromise(appOrParcel, hardFail) {
     return reasonableTime(appOrParcel, "bootstrap")
       .then(successfulBootstrap)
       .catch((err) => {
+        if (__PROFILE__) {
+          addProfileEntry(
+            "application",
+            toName(appOrParcel),
+            "bootstrap",
+            startTime,
+            Date.now(),
+            false
+          );
+        }
+
         if (hardFail) {
           throw transformErr(err, appOrParcel, SKIP_BECAUSE_BROKEN);
         } else {
@@ -34,6 +53,18 @@ export function toBootstrapPromise(appOrParcel, hardFail) {
 
   function successfulBootstrap() {
     appOrParcel.status = NOT_MOUNTED;
+
+    if (__PROFILE__) {
+      addProfileEntry(
+        "application",
+        toName(appOrParcel),
+        "bootstrap",
+        startTime,
+        Date.now(),
+        true
+      );
+    }
+
     return appOrParcel;
   }
 }

--- a/src/lifecycles/load.js
+++ b/src/lifecycles/load.js
@@ -37,7 +37,7 @@ export function toLoadPromise(appOrParcel) {
     let startTime;
 
     if (__PROFILE__) {
-      startTime = Date.now();
+      startTime = performance.now();
     }
 
     appOrParcel.status = LOADING_SOURCE_CODE;
@@ -151,7 +151,7 @@ export function toLoadPromise(appOrParcel) {
               toName(appOrParcel),
               "load",
               startTime,
-              Date.now(),
+              performance.now(),
               true
             );
           }
@@ -177,7 +177,7 @@ export function toLoadPromise(appOrParcel) {
             toName(appOrParcel),
             "load",
             startTime,
-            Date.now(),
+            performance.now(),
             false
           );
         }

--- a/src/lifecycles/mount.js
+++ b/src/lifecycles/mount.js
@@ -23,7 +23,7 @@ export function toMountPromise(appOrParcel, hardFail) {
     let startTime;
 
     if (__PROFILE__) {
-      startTime = Date.now();
+      startTime = performance.now();
     }
 
     if (!beforeFirstMountFired) {
@@ -48,7 +48,7 @@ export function toMountPromise(appOrParcel, hardFail) {
             toName(appOrParcel),
             "mount",
             startTime,
-            Date.now(),
+            performance.now(),
             true
           );
         }
@@ -72,7 +72,7 @@ export function toMountPromise(appOrParcel, hardFail) {
               toName(appOrParcel),
               "mount",
               startTime,
-              Date.now(),
+              performance.now(),
               false
             );
           }

--- a/src/lifecycles/unload.js
+++ b/src/lifecycles/unload.js
@@ -49,7 +49,7 @@ export function toUnloadPromise(appOrParcel) {
     let startTime;
 
     if (__PROFILE__) {
-      startTime = Date.now();
+      startTime = performance.now();
     }
 
     const unloadPromise =
@@ -67,7 +67,7 @@ export function toUnloadPromise(appOrParcel) {
             toName(appOrParcel),
             "unload",
             startTime,
-            Date.now(),
+            performance.now(),
             true
           );
         }
@@ -83,7 +83,7 @@ export function toUnloadPromise(appOrParcel) {
             toName(appOrParcel),
             "unload",
             startTime,
-            Date.now(),
+            performance.now(),
             false
           );
         }

--- a/src/lifecycles/unmount.js
+++ b/src/lifecycles/unmount.js
@@ -18,7 +18,7 @@ export function toUnmountPromise(appOrParcel, hardFail) {
     let startTime;
 
     if (__PROFILE__) {
-      startTime = Date.now();
+      startTime = performance.now();
     }
 
     appOrParcel.status = UNMOUNTING;
@@ -59,7 +59,7 @@ export function toUnmountPromise(appOrParcel, hardFail) {
               toName(appOrParcel),
               "unmount",
               startTime,
-              Date.now(),
+              performance.now(),
               true
             );
           }
@@ -71,7 +71,7 @@ export function toUnmountPromise(appOrParcel, hardFail) {
               toName(appOrParcel),
               "unmount",
               startTime,
-              Date.now(),
+              performance.now(),
               false
             );
           }

--- a/src/lifecycles/unmount.js
+++ b/src/lifecycles/unmount.js
@@ -3,15 +3,24 @@ import {
   NOT_MOUNTED,
   MOUNTED,
   SKIP_BECAUSE_BROKEN,
+  toName,
 } from "../applications/app.helpers.js";
 import { handleAppError, transformErr } from "../applications/app-errors.js";
 import { reasonableTime } from "../applications/timeouts.js";
+import { addProfileEntry } from "../devtools/profiler.js";
 
 export function toUnmountPromise(appOrParcel, hardFail) {
   return Promise.resolve().then(() => {
     if (appOrParcel.status !== MOUNTED) {
       return appOrParcel;
     }
+
+    let startTime;
+
+    if (__PROFILE__) {
+      startTime = Date.now();
+    }
+
     appOrParcel.status = UNMOUNTING;
 
     const unmountChildrenParcels = Object.keys(appOrParcel.parcels).map(
@@ -37,20 +46,43 @@ export function toUnmountPromise(appOrParcel, hardFail) {
 
     function unmountAppOrParcel() {
       // We always try to unmount the appOrParcel, even if the children parcels failed to unmount.
-      return reasonableTime(appOrParcel, "unmount")
-        .then(() => {
+      return reasonableTime(appOrParcel, "unmount").then(
+        () => {
           // The appOrParcel needs to stay in a broken status if its children parcels fail to unmount
           if (!parcelError) {
             appOrParcel.status = NOT_MOUNTED;
           }
-        })
-        .catch((err) => {
+
+          if (__PROFILE__) {
+            addProfileEntry(
+              "application",
+              toName(appOrParcel),
+              "unmount",
+              startTime,
+              Date.now(),
+              true
+            );
+          }
+        },
+        (err) => {
+          if (__PROFILE__) {
+            addProfileEntry(
+              "application",
+              toName(appOrParcel),
+              "unmount",
+              startTime,
+              Date.now(),
+              false
+            );
+          }
+
           if (hardFail) {
             throw transformErr(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           } else {
             handleAppError(err, appOrParcel, SKIP_BECAUSE_BROKEN);
           }
-        });
+        }
+      );
     }
   });
 }

--- a/src/single-spa.profile.js
+++ b/src/single-spa.profile.js
@@ -1,0 +1,3 @@
+export * from "./single-spa.js";
+
+export * from "./devtools/profiler-api.js";


### PR DESCRIPTION
This sets up the approach for profiling and then implements it for application and parcel lifecycles. To start with, I've just added the profiler to the single-spa dev build, not prod build. I know that React has a production profiler build but didn't think the performance difference between the dev and prod build to be large enough to justify adding a bunch of new bundles to the tarball published to npm.

I'm most interested in feedback on the profiler api and what data we track. My idea is that single-spa-inspector will call getProfilerData and then show some of the data in the browser extension and maybe even provide a way to download the profiler data to a CSV file or something.

Future PRs will add profiler events within the `reroute` function to track which parts of the rerouting takes longest.