### PR TITLE
fix(types): fix SingleSpaAppsByNewStatus interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "testDir": "spec/typings",
     "compilerOptions": {
       "lib": [
-        "dom"
+        "dom",
+        "ES2015"
       ]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@babel/core': ^7.9.0
@@ -33,11 +33,11 @@ specifiers:
 
 devDependencies:
   '@babel/core': 7.14.6
-  '@babel/eslint-parser': 7.14.7_@babel+core@7.14.6+eslint@7.30.0
+  '@babel/eslint-parser': 7.14.7_7gtqattjpgwrsag2xakxcw7g2e
   '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.14.6
   '@babel/preset-env': 7.14.7_@babel+core@7.14.6
   '@babel/runtime': 7.14.6
-  '@rollup/plugin-babel': 5.3.0_@babel+core@7.14.6+rollup@2.52.7
+  '@rollup/plugin-babel': 5.3.0_bcjx53pd6civd2eh7ykhrwc55e
   '@rollup/plugin-commonjs': 19.0.0_rollup@2.52.7
   '@rollup/plugin-node-resolve': 13.0.0_rollup@2.52.7
   '@rollup/plugin-replace': 2.4.2_rollup@2.52.7
@@ -105,7 +105,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.14.7_@babel+core@7.14.6+eslint@7.30.0:
+  /@babel/eslint-parser/7.14.7_7gtqattjpgwrsag2xakxcw7g2e:
     resolution: {integrity: sha512-6WPwZqO5priAGIwV6msJcdc9TsEPzYeYdS/Xuoap+/ihkgN6dzHp2bcAAwyWZ5bLzk0vvjDmKvRwkqNaiJ8BiQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -364,6 +364,8 @@ packages:
     resolution: {integrity: sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.14.5
     dev: true
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.14.5_@babel+core@7.14.6:
@@ -1489,7 +1491,7 @@ packages:
       fastq: 1.11.0
     dev: true
 
-  /@rollup/plugin-babel/5.3.0_@babel+core@7.14.6+rollup@2.52.7:
+  /@rollup/plugin-babel/5.3.0_bcjx53pd6civd2eh7ykhrwc55e:
     resolution: {integrity: sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -1734,8 +1736,8 @@ packages:
     hasBin: true
     dev: true
 
-  /acorn/8.4.1:
-    resolution: {integrity: sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==}
+  /acorn/8.7.1:
+    resolution: {integrity: sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -2671,6 +2673,7 @@ packages:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -3556,7 +3559,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.5
-      acorn: 8.4.1
+      acorn: 8.7.1
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
@@ -4541,6 +4544,7 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
+      acorn: 8.7.1
       commander: 2.20.3
       source-map: 0.7.3
       source-map-support: 0.5.19

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -102,10 +102,10 @@ declare module "single-spa" {
       | "SKIP_BECAUSE_BROKEN";
   }
   interface SingleSpaAppsByNewStatus {
-    [MOUNTED]: [];
-    [NOT_MOUNTED]: [];
-    [NOT_LOADED]: [];
-    [SKIP_BECAUSE_BROKEN]: [];
+    [MOUNTED]: string[];
+    [NOT_MOUNTED]: string[];
+    [NOT_LOADED]: string[];
+    [SKIP_BECAUSE_BROKEN]: string[];
   }
   export type SingleSpaCustomEventDetail = {
     newAppStatuses: SingleSpaNewAppStatus;

--- a/typings/single-spa.test-d.ts
+++ b/typings/single-spa.test-d.ts
@@ -9,6 +9,7 @@ import {
   Parcel,
   ParcelConfig,
   patchHistoryApi,
+  MOUNTED,
 } from "single-spa";
 import { expectError, expectType } from "tsd";
 
@@ -81,6 +82,7 @@ window.addEventListener("single-spa:routing-event", ((
   expectType<string>(evt.detail.newUrl);
   expectType<boolean>(evt.detail.navigationIsCanceled);
   expectType<(() => void) | undefined>(evt.detail.cancelNavigation);
+  expectType<string[]>(evt.detail.appsByNewStatus[MOUNTED]);
 }) as EventListener);
 
 expectType<void>(patchHistoryApi());


### PR DESCRIPTION
The `SingleSpaAppsByNewStatus` interface currently has empty arrays as its values, although they should be string arrays.

Closes #987