### PR TITLE
Add `types` entry to support NodeNext `module` and `moduleResolution`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
         "require": "./lib/es2015/umd/single-spa.min.cjs"
       },
       "default": {
-        "import": "./lib/es2015/esm/single-spa.min.js",
+        "import": {
+          "types": "./typings/single-spa.d.ts",
+          "default": "./lib/es2015/esm/single-spa.min.js"
+        },
         "require": "./lib/es2015/umd/single-spa.min.cjs"
       }
     },


### PR DESCRIPTION
TypeScript 4.7 has just been released which added support for Node16/NodeNext module

```json
{
  "compilerOptions": {
    "module": "NodeNext",
    "moduleResolution": "NodeNext"
  }
}
```

I think this update is required (I tested it in my personal project) for TS to look up type declarations (see [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing)).

By the way, I don't know what are `development` entry [here](https://github.com/ICodeMyOwnLife/single-spa/blob/6.0/package.json#L10) and `production` entry [here](https://github.com/ICodeMyOwnLife/single-spa/blob/6.0/package.json#L14) for? They seem not working for me. IMO, they should be in this format - but I could be wrong

```json
{
  "exports": {
    "./development": {...}, // for importing "single-spa/development"
    "./production": {...}, // for importing "single-spa/production"
    ".": {...}, // for importing "single-spa"
    /* other entries */
  }
}
```