### PR TITLE
provide link to slack from issue questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
-    - name: Questions and Help
-      url: https://join.slack.com/t/single-spa/shared_invite/zt-yxfqpl2u-PNx3uZtS3pgAXbOBWsdwOA
-      about: Join the community on Slack to get quicker help from us and the community. And helping us answer the questions of others allows us to answer your question faster.
+  - name: Questions and Help
+    url: https://join.slack.com/t/single-spa/shared_invite/zt-yxfqpl2u-PNx3uZtS3pgAXbOBWsdwOA
+    about: Join the community on Slack to get quicker help from us and the community. And helping us answer the questions of others allows us to answer your question faster.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+    - name: Questions and Help
+      url: https://join.slack.com/t/single-spa/shared_invite/zt-yxfqpl2u-PNx3uZtS3pgAXbOBWsdwOA
+      about: Join the community on Slack to get quicker help from us and the community. And helping us answer the questions of others allows us to answer your question faster.


### PR DESCRIPTION
Providing people a link to Slack to answer their questions faster will also help us keep the issue queue focused. If people don't want this Github still provides them an option to open a blank issue.