### PR TITLE
Update history.pushState in navigation-events.js

### DIFF
--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -58,7 +58,7 @@ export function navigateToUrl(obj) {
     window.location.hash = destination.hash;
   } else {
     // different path, host, or query params
-    window.history.pushState(null, null, url);
+    window.history.pushState({}, '', url);
   }
 }
 


### PR DESCRIPTION
In my Vue3 application, the router worked incorrectly if the parameters were null, null When following the recommendations, everything works well. https://developer.mozilla.org/en-US/docs/Web/API/History/pushState