### PR TITLE
Enhance `getProps` to Extract Dynamic Route Parameters

### DIFF
--- a/src/applications/app.helpers.js
+++ b/src/applications/app.helpers.js
@@ -38,3 +38,68 @@ export function isParcel(appOrParcel) {
 export function objectType(appOrParcel) {
   return isParcel(appOrParcel) ? "parcel" : "application";
 }
+
+export function toDynamicPathRegexInfo(path, exactMatch) {
+  let lastIndex = 0,
+    inDynamic = false,
+    regexStr = "^";
+
+  const paramNames = [];
+
+  if (path[0] !== "/") {
+    path = "/" + path;
+  }
+
+  for (let charIndex = 0; charIndex < path.length; charIndex++) {
+    const char = path[charIndex];
+    const startOfDynamic = !inDynamic && char === ":";
+    const endOfDynamic = inDynamic && char === "/";
+    if (startOfDynamic || endOfDynamic) {
+      appendToRegex(charIndex);
+    }
+    if (startOfDynamic) {
+      const paramName = path.slice(charIndex + 1, path.indexOf("/", charIndex));
+      paramNames.push(paramName);
+    }
+  }
+
+  appendToRegex(path.length);
+  return { regex: new RegExp(regexStr, "i"), paramNames };
+
+  function appendToRegex(index) {
+    const anyCharMaybeTrailingSlashRegex = "[^/]+/?";
+    const commonStringSubPath = escapeStrRegex(path.slice(lastIndex, index));
+
+    regexStr += inDynamic
+      ? anyCharMaybeTrailingSlashRegex
+      : commonStringSubPath;
+
+    if (index === path.length) {
+      if (inDynamic) {
+        if (exactMatch) {
+          // Ensure exact match paths that end in a dynamic portion don't match
+          // urls with characters after a slash after the dynamic portion.
+          regexStr += "$";
+        }
+      } else {
+        // For exact matches, expect no more characters. Otherwise, allow
+        // any characters.
+        const suffix = exactMatch ? "" : ".*";
+
+        regexStr =
+          // use charAt instead as we could not use es6 method endsWith
+          regexStr.charAt(regexStr.length - 1) === "/"
+            ? `${regexStr}${suffix}$`
+            : `${regexStr}(/${suffix})?(#.*)?$`;
+      }
+    }
+
+    inDynamic = !inDynamic;
+    lastIndex = index;
+  }
+
+  function escapeStrRegex(str) {
+    // borrowed from https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js
+    return str.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
+  }
+}

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -10,6 +10,7 @@ import {
   SKIP_BECAUSE_BROKEN,
   LOADING_SOURCE_CODE,
   shouldBeActive,
+  toDynamicPathRegexInfo,
 } from "./app.helpers.js";
 import { reroute } from "../navigation/reroute.js";
 import { find } from "../utils/find.js";
@@ -412,7 +413,7 @@ function sanitizeActiveWhen(activeWhen) {
 }
 
 export function pathToActiveWhen(path, exactMatch) {
-  const regex = toDynamicPathValidatorRegex(path, exactMatch);
+  const { regex } = toDynamicPathRegexInfo(path, exactMatch);
 
   return (location) => {
     // compatible with IE10
@@ -426,63 +427,4 @@ export function pathToActiveWhen(path, exactMatch) {
       .split("?")[0];
     return regex.test(route);
   };
-}
-
-function toDynamicPathValidatorRegex(path, exactMatch) {
-  let lastIndex = 0,
-    inDynamic = false,
-    regexStr = "^";
-
-  if (path[0] !== "/") {
-    path = "/" + path;
-  }
-
-  for (let charIndex = 0; charIndex < path.length; charIndex++) {
-    const char = path[charIndex];
-    const startOfDynamic = !inDynamic && char === ":";
-    const endOfDynamic = inDynamic && char === "/";
-    if (startOfDynamic || endOfDynamic) {
-      appendToRegex(charIndex);
-    }
-  }
-
-  appendToRegex(path.length);
-  return new RegExp(regexStr, "i");
-
-  function appendToRegex(index) {
-    const anyCharMaybeTrailingSlashRegex = "[^/]+/?";
-    const commonStringSubPath = escapeStrRegex(path.slice(lastIndex, index));
-
-    regexStr += inDynamic
-      ? anyCharMaybeTrailingSlashRegex
-      : commonStringSubPath;
-
-    if (index === path.length) {
-      if (inDynamic) {
-        if (exactMatch) {
-          // Ensure exact match paths that end in a dynamic portion don't match
-          // urls with characters after a slash after the dynamic portion.
-          regexStr += "$";
-        }
-      } else {
-        // For exact matches, expect no more characters. Otherwise, allow
-        // any characters.
-        const suffix = exactMatch ? "" : ".*";
-
-        regexStr =
-          // use charAt instead as we could not use es6 method endsWith
-          regexStr.charAt(regexStr.length - 1) === "/"
-            ? `${regexStr}${suffix}$`
-            : `${regexStr}(/${suffix})?(#.*)?$`;
-      }
-    }
-
-    inDynamic = !inDynamic;
-    lastIndex = index;
-  }
-
-  function escapeStrRegex(str) {
-    // borrowed from https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js
-    return str.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
-  }
 }


### PR DESCRIPTION
This PR improves the [getProps](https://github.com/single-spa/single-spa/blob/f28b5963be1484583a072c8145ac0b5a28d91235/src/lifecycles/prop.helpers.js#L7) function  by enabling it to extract dynamic route parameters and include them in the final props object. These modifications enhance the functionality of single-spa applications by providing developers with access to dynamic route parameters within the app props.