### PR TITLE
Add missing UNLOADING export

### DIFF
--- a/src/single-spa.js
+++ b/src/single-spa.js
@@ -34,6 +34,7 @@ export {
   UPDATING,
   LOAD_ERROR,
   MOUNTED,
+  UNLOADING,
   UNMOUNTING,
   SKIP_BECAUSE_BROKEN,
 } from "./applications/app.helpers.js";


### PR DESCRIPTION
UNLOADING is declared on TypeScript types but is not being exported on single-spa.js

resolves https://github.com/single-spa/single-spa/issues/1116