### PR TITLE
Fix/missing types

### DIFF
--- a/.changeset/tiny-trainers-leave.md
+++ b/.changeset/tiny-trainers-leave.md
@@ -1,0 +1,5 @@
+---
+"single-spa": patch
+---
+
+Fix issue with missing types when using module resolution strategies other than node10

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ coverage/
 dist/
 .DS_Store
 yarn-error.log
+
+# This file is a copy of the single-spa.d.ts file. See scripts/copyTypes.
+typings/single-spa.d.cts

--- a/package.json
+++ b/package.json
@@ -8,16 +8,34 @@
   "exports": {
     ".": {
       "development": {
-        "import": "./lib/es2015/esm/single-spa.dev.js",
-        "require": "./lib/es2015/umd/single-spa.dev.cjs"
+        "import": {
+          "types": "./typings/single-spa.d.ts",
+          "default": "./lib/es2015/esm/single-spa.dev.js"
+        },
+        "require": {
+          "types": "./typings/single-spa.d.cts",
+          "default": "./lib/es2015/umd/single-spa.dev.cjs"
+        }
       },
       "production": {
-        "import": "./lib/es2015/esm/single-spa.min.js",
-        "require": "./lib/es2015/umd/single-spa.min.cjs"
+        "import": {
+          "types": "./typings/single-spa.d.ts",
+          "default": "./lib/es2015/esm/single-spa.min.js"
+        },
+        "require": {
+          "types": "./typings/single-spa.d.cts",
+          "default": "./lib/es2015/umd/single-spa.min.cjs"
+        }
       },
       "default": {
-        "import": "./lib/es2015/esm/single-spa.min.js",
-        "require": "./lib/es2015/umd/single-spa.min.cjs"
+        "import": {
+          "types": "./typings/single-spa.d.ts",
+          "default": "./lib/es2015/esm/single-spa.min.js"
+        },
+        "require": {
+          "types": "./typings/single-spa.d.cts",
+          "default": "./lib/es2015/umd/single-spa.min.cjs"
+        }
       }
     },
     "./package.json": "./package.json",
@@ -54,7 +72,8 @@
   },
   "files": [
     "lib",
-    "typings/single-spa.d.ts"
+    "typings/single-spa.d.ts",
+    "typings/single-spa.d.cts"
   ],
   "homepage": "https://single-spa.js.org",
   "repository": "https://github.com/single-spa/single-spa",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
   },
   "module": "lib/es2015/esm/single-spa.min.js",
   "scripts": {
-    "build": "pnpm run clean && concurrently pnpm:build:dev pnpm:build:prod",
+    "build": "pnpm run clean && concurrently pnpm:build:dev pnpm:build:prod pnpm:build:types",
     "build:prod": "rollup -c --environment NODE_ENV:'production'",
     "build:dev": "rollup -c",
     "build:analyze": "rollup -c --environment ANALYZER:'analyzer'",
+    "build:types": "node scripts/copy-types.js",
     "watch": "rollup -c -w",
     "clean": "rimraf lib",
     "test": "concurrently -n w: 'pnpm:test:*'",

--- a/scripts/copy-types.js
+++ b/scripts/copy-types.js
@@ -1,0 +1,12 @@
+// A single declaration file CAN NOT represent both CommonJS and ESM module, even if their content is identical.
+// See https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md#common-causes for more information.
+
+import { copyFileSync } from "fs";
+
+const esmTypesFile = "typings/single-spa.d.ts";
+const cjsTypesFile = "typings/single-spa.d.cts";
+
+copyFileSync(esmTypesFile, cjsTypesFile);
+
+// eslint-disable-next-line no-console
+console.log(`Copied ${esmTypesFile} to ${cjsTypesFile}`);


### PR DESCRIPTION
Modfied exports/types to resolve issue with missing types when using node16, and bundler resolution strategies. This is not a breaking change.

Before:

![image](https://github.com/single-spa/single-spa/assets/9189985/d7842b3f-d6d9-40bf-b4a6-bd0d4900c14b)

After:

![image](https://github.com/single-spa/single-spa/assets/9189985/c261ab43-910e-4353-a845-d1be39c7827d)
