### PR TITLE
feat: Add global logger object

### DIFF
--- a/spec/apis/logging.spec.js
+++ b/spec/apis/logging.spec.js
@@ -1,8 +1,8 @@
-import { logger, setLogger } from '../../src/utils/logging';
+import { logger, configureLogger } from '../../src/utils/logging';
 
 describe('logger module', () => {
     beforeEach(() => {
-        setLogger(true);
+        configureLogger(console);
     });
     const defaultConsoleTests = [
         {
@@ -35,16 +35,16 @@ describe('logger module', () => {
             spy.mockReset();
         });
     });
-    describe('setLogger', () => {
+    describe('configureLogger', () => {
         defaultConsoleTests.forEach(tc => {
-            it(`Should silence all logging coming from the "${tc.method}" method after calling setLogger with "false" as argument.`, () => {
+            it(`Should silence all logging coming from the "${tc.method}" method after calling configureLogger with "null" as argument.`, () => {
                 // Arrange.
                 const spy = jest.spyOn(console, tc.method);
                 tc.fn("Testing.");
                 expect(spy).toHaveBeenCalledTimes(1);
                 
                 // Act.
-                setLogger(false);
+                configureLogger(null);
 
                 // Assert.
                 tc.fn("Testing 2.");
@@ -59,12 +59,12 @@ describe('logger module', () => {
             error: jest.fn()
         };
         defaultConsoleTests.forEach(tc => {
-            it(`Should call the provided custom logger's "${tc.method}" method instead of logging directly to the console when setLogger is called with a custom logger object as argument.`, () => {
+            it(`Should call the provided custom logger's "${tc.method}" method instead of logging directly to the console when configureLogger is called with a custom logger object as argument.`, () => {
                 // Arrange.
                 const spy = jest.spyOn(console, tc.method);
 
                 // Act.
-                setLogger(customLogger);
+                configureLogger(customLogger);
 
                 // Assert.
                 tc.fn("Testing.");

--- a/spec/apis/logging.spec.js
+++ b/spec/apis/logging.spec.js
@@ -1,0 +1,82 @@
+import { logger, setLogger } from '../../src/utils/logging';
+
+describe('logger module', () => {
+    beforeEach(() => {
+        setLogger(true);
+    });
+    // afterEach(() => {
+    //     ['debug', 'info', 'warn', 'error'].forEach(m => {
+    //         console[m]?.mockRestore();
+    //     });
+    // });
+    const defaultConsoleTests = [
+        {
+            method: "debug",
+            fn: (msg) => logger.debug(msg)
+        },
+        {
+            method: "info",
+            fn: (msg) => logger.info(msg)
+        },
+        {
+            method: "warn",
+            fn: (msg) => logger.warn(msg)
+        },
+        {
+            method: "error",
+            fn: (msg) => logger.error(msg)
+        },
+    ];
+    defaultConsoleTests.forEach(tc => {
+        it(`Should, by default, log all ${tc.method} messages to the console.`, () => {
+            // Arrange.
+            const spy = jest.spyOn(console, tc.method);
+
+            // Act.
+            tc.fn("Testing.");
+
+            // Assert.
+            expect(spy).toHaveBeenCalledTimes(1);
+            spy.mockReset();
+        });
+    });
+    describe('setLogger', () => {
+        defaultConsoleTests.forEach(tc => {
+            it(`Should silence all logging coming from the "${tc.method}" method after calling setLogger with "false" as argument.`, () => {
+                // Arrange.
+                const spy = jest.spyOn(console, tc.method);
+                tc.fn("Testing.");
+                expect(spy).toHaveBeenCalledTimes(1);
+                
+                // Act.
+                setLogger(false);
+
+                // Assert.
+                tc.fn("Testing 2.");
+                expect(spy).toHaveBeenCalledTimes(1);
+                spy.mockReset();
+            });
+        });
+        const customLogger = {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn()
+        };
+        defaultConsoleTests.forEach(tc => {
+            it(`Should call the provided custom logger's "${tc.method}" method instead of logging directly to the console when setLogger is called with a custom logger object as argument.`, () => {
+                // Arrange.
+                const spy = jest.spyOn(console, tc.method);
+
+                // Act.
+                setLogger(customLogger);
+
+                // Assert.
+                tc.fn("Testing.");
+                expect(customLogger[tc.method]).toHaveBeenCalledTimes(1);
+                expect(spy).not.toHaveBeenCalled();
+                spy.mockReset();
+            });
+        });
+    });
+});

--- a/spec/apis/logging.spec.js
+++ b/spec/apis/logging.spec.js
@@ -4,11 +4,6 @@ describe('logger module', () => {
     beforeEach(() => {
         setLogger(true);
     });
-    // afterEach(() => {
-    //     ['debug', 'info', 'warn', 'error'].forEach(m => {
-    //         console[m]?.mockRestore();
-    //     });
-    // });
     const defaultConsoleTests = [
         {
             method: "debug",

--- a/src/applications/app-errors.js
+++ b/src/applications/app-errors.js
@@ -1,4 +1,5 @@
 import { objectType, toName } from "./app.helpers";
+import { logger } from "../utils/logging";
 
 let errorHandlers = [];
 
@@ -72,7 +73,7 @@ export function transformErr(ogErr, appOrParcel, newStatus) {
     }
     result = ogErr;
   } else {
-    console.warn(
+    logger.warn(
       formatErrorMessage(
         30,
         __DEV__ &&

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -1,4 +1,5 @@
 import { ensureJQuerySupport } from "../jquery-support.js";
+import { logger } from "../utils/logging.js"
 import {
   isActive,
   toName,
@@ -109,7 +110,7 @@ export function registerApplication(
 
     setTimeout(() => {
       if (!isStarted()) {
-        console.warn(
+        logger.warn(
           formatErrorMessage(
             1,
             __DEV__ &&

--- a/src/applications/timeouts.js
+++ b/src/applications/timeouts.js
@@ -2,6 +2,7 @@ import { assign } from "../utils/assign";
 import { getProps } from "../lifecycles/prop.helpers";
 import { objectType, toName } from "./app.helpers";
 import { formatErrorMessage } from "./app-errors";
+import { logger } from "../utils/logging";
 
 const defaultWarningMillis = 1000;
 
@@ -146,13 +147,13 @@ export function reasonableTime(appOrParcel, lifecycle) {
           if (timeoutConfig.dieOnTimeout) {
             reject(Error(errMsg));
           } else {
-            console.error(errMsg);
+            logger.error(errMsg);
             //don't resolve or reject, we're waiting this one out
           }
         } else if (!errored) {
           const numWarnings = shouldError;
           const numMillis = numWarnings * warningPeriod;
-          console.warn(errMsg);
+          logger.warn(errMsg);
           if (numMillis + warningPeriod < timeoutConfig.millis) {
             setTimeout(() => maybeTimingOut(numWarnings + 1), warningPeriod);
           }

--- a/src/lifecycles/load.js
+++ b/src/lifecycles/load.js
@@ -20,6 +20,7 @@ import {
 import { getProps } from "./prop.helpers.js";
 import { assign } from "../utils/assign.js";
 import { addProfileEntry } from "../devtools/profiler.js";
+import { logger } from "../utils/logging.js";
 
 export function toLoadPromise(appOrParcel) {
   return Promise.resolve().then(() => {
@@ -107,7 +108,7 @@ export function toLoadPromise(appOrParcel) {
             try {
               appOptsStr = JSON.stringify(appOpts);
             } catch {}
-            console.error(
+            logger.error(
               formatErrorMessage(
                 validationErrCode,
                 __DEV__ &&

--- a/src/lifecycles/prop.helpers.js
+++ b/src/lifecycles/prop.helpers.js
@@ -3,6 +3,7 @@ import { mountParcel } from "../parcels/mount-parcel.js";
 import { assign } from "../utils/assign.js";
 import { isParcel, toName } from "../applications/app.helpers.js";
 import { formatErrorMessage } from "../applications/app-errors.js";
+import { logger } from "../utils/logging.js";
 
 export function getProps(appOrParcel) {
   const name = toName(appOrParcel);
@@ -16,7 +17,7 @@ export function getProps(appOrParcel) {
     Array.isArray(customProps)
   ) {
     customProps = {};
-    console.warn(
+    logger.warn(
       formatErrorMessage(
         40,
         __DEV__ &&

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -2,6 +2,7 @@ import { reroute } from "./reroute.js";
 import { find } from "../utils/find.js";
 import { formatErrorMessage } from "../applications/app-errors.js";
 import { isInBrowser } from "../utils/runtime-environment.js";
+import { logger } from "../utils/logging.js";
 
 /* We capture navigation event listeners so that we can make sure
  * that application navigation listeners are not called until
@@ -201,7 +202,7 @@ export function patchHistoryApi(opts) {
 // apis like getAppNames().
 if (isInBrowser) {
   if (window.singleSpaNavigate) {
-    console.warn(
+    logger.warn(
       formatErrorMessage(
         41,
         __DEV__ &&

--- a/src/navigation/reroute.js
+++ b/src/navigation/reroute.js
@@ -26,6 +26,7 @@ import { assign } from "../utils/assign.js";
 import { isInBrowser } from "../utils/runtime-environment.js";
 import { formatErrorMessage } from "../applications/app-errors.js";
 import { addProfileEntry } from "../devtools/profiler.js";
+import { logger } from "../utils/logging.js";
 
 let appChangeUnderway = false,
   peopleWaitingOnAppChange = [],
@@ -89,7 +90,7 @@ export function reroute(
       typeof val?.then === "function" ? val : Promise.resolve(val);
     cancelPromises.push(
       promise.catch((err) => {
-        console.warn(
+        logger.warn(
           Error(
             formatErrorMessage(
               42,
@@ -98,7 +99,7 @@ export function reroute(
             )
           )
         );
-        console.warn(err);
+        logger.warn(err);
 
         // Interpret a Promise rejection to mean that the navigation should not be canceled
         return false;

--- a/src/single-spa.js
+++ b/src/single-spa.js
@@ -1,4 +1,5 @@
 export { start } from "./start.js";
+export { setLogger } from "./utils/logging.js";
 export { ensureJQuerySupport } from "./jquery-support.js";
 export {
   setBootstrapMaxTime,

--- a/src/single-spa.js
+++ b/src/single-spa.js
@@ -1,5 +1,5 @@
 export { start } from "./start.js";
-export { setLogger } from "./utils/logging.js";
+export { configureLogger } from "./utils/logging.js";
 export { ensureJQuerySupport } from "./jquery-support.js";
 export {
   setBootstrapMaxTime,

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,0 +1,87 @@
+/* export interface ILogger {
+    debug(...data: any[]): void;
+    info(...data: any[]): void;
+    warn(...data: any[]): void;
+    error(...data: any[]): void;
+}
+
+const silentLogger: ILogger = {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop
+};
+
+let loggerInstance: ILogger = globalThis?.console;
+
+export function setLogger(logger: boolean | ILogger) {
+    if (!logger) {
+        loggerInstance = silentLogger;
+        return;
+    }
+    if (logger === true) {
+        loggerInstance = console;
+        return;
+    }
+    loggerInstance = logger;
+}
+
+export const logger = {
+    debug(...data) {
+        loggerInstance.debug(...data);
+    },
+    info(...data) {
+        loggerInstance.info(...data);
+    },
+    warn(...data) {
+        loggerInstance.warn(...data);
+    },
+    error(...data) {
+        loggerInstance.error(...data);
+    }
+};
+*/
+
+function noop() { }
+
+const silentLogger = {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop
+};
+
+let loggerInstance = globalThis?.console;
+
+/**
+ * Sets a logger object to be used by the single-spa library to emit log messages.  By default, 
+ * log messages are emitted to the console.
+ * @param logger A custom logger object, or the value `true` to log to the console, or the value 
+ * `false` to deactivate all logging.
+ */
+export function setLogger(logger) {
+    if (!logger) {
+        loggerInstance = silentLogger;
+        return;
+    }
+    if (logger === true) {
+        loggerInstance = console;
+        return;
+    }
+    loggerInstance = logger;
+}
+
+export const logger = {
+    debug(...data) {
+        loggerInstance.debug(...data);
+    },
+    info(...data) {
+        loggerInstance.info(...data);
+    },
+    warn(...data) {
+        loggerInstance.warn(...data);
+    },
+    error(...data) {
+        loggerInstance.error(...data);
+    }
+};

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,10 +1,4 @@
-/* export interface ILogger {
-    debug(...data: any[]): void;
-    info(...data: any[]): void;
-    warn(...data: any[]): void;
-    error(...data: any[]): void;
-}
-
+/* 
 const silentLogger: ILogger = {
     debug: noop,
     info: noop,
@@ -14,17 +8,13 @@ const silentLogger: ILogger = {
 
 let loggerInstance: ILogger = globalThis?.console;
 
-export function setLogger(logger: boolean | ILogger) {
+export function configureLogger(logger: null | ILogger) {
     if (!logger) {
         loggerInstance = silentLogger;
         return;
     }
-    if (logger === true) {
-        loggerInstance = console;
-        return;
-    }
     loggerInstance = logger;
-}
+};
 
 export const logger = {
     debug(...data) {
@@ -59,17 +49,13 @@ let loggerInstance = globalThis?.console;
  * @param logger A custom logger object, or the value `true` to log to the console, or the value 
  * `false` to deactivate all logging.
  */
-export function setLogger(logger) {
+export function configureLogger(logger) {
     if (!logger) {
         loggerInstance = silentLogger;
         return;
     }
-    if (logger === true) {
-        loggerInstance = console;
-        return;
-    }
     loggerInstance = logger;
-}
+};
 
 export const logger = {
     debug(...data) {

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -46,15 +46,25 @@ let loggerInstance = globalThis?.console;
 /**
  * Sets a logger object to be used by the single-spa library to emit log messages.  By default, 
  * log messages are emitted to the console.
- * @param logger A custom logger object, or the value `true` to log to the console, or the value 
- * `false` to deactivate all logging.
+ * @param logger A custom logger object, or `null` to silence logging.  To restore logging to 
+ * the console, pass the console object.
  */
 export function configureLogger(logger) {
-    if (!logger) {
+    if (logger === null) {
         loggerInstance = silentLogger;
         return;
     }
-    loggerInstance = logger;
+    if (typeof logger === 'object' &&
+        typeof logger.debug === 'function'
+        && typeof logger.info === "function"
+        && typeof logger.warn === "function"
+        && typeof logger.error === "function"
+    ) {
+        loggerInstance = logger;
+    }
+    else {
+        throw new Error("Invalid argument:  The given logger does not conform to the expected specification.")
+    }
 };
 
 export const logger = {

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -32,6 +32,8 @@ export const logger = {
 };
 */
 
+import { formatErrorMessage } from "../applications/app-errors";
+
 function noop() { }
 
 const silentLogger = {
@@ -63,7 +65,13 @@ export function configureLogger(logger) {
         loggerInstance = logger;
     }
     else {
-        throw new Error("Invalid argument:  The given logger does not conform to the expected specification.")
+        loggerInstance.warn(
+            formatErrorMessage(
+                42,
+                __DEV__ &&
+                "The given logger does not conform to the ILogger interface."
+            )
+        );
     }
 };
 

--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -235,4 +235,19 @@ declare module "single-spa" {
   ): ActivityFn;
 
   export function patchHistoryApi(opts?: StartOpts): void;
+
+  export interface ILogger {
+    debug(...data: any[]): void;
+    info(...data: any[]): void;
+    warn(...data: any[]): void;
+    error(...data: any[]): void;
+  }
+
+  /**
+   * Sets a logger object to be used by the single-spa library to emit log messages.  By default, 
+   * log messages are emitted to the console.
+   * @param logger A custom logger object, or the value `true` to log to the console, or the value 
+   * `false` to deactivate all logging.
+   */
+  export function configureLogger(logger: null | ILogger): void;
 }

--- a/typings/single-spa.test-d.ts
+++ b/typings/single-spa.test-d.ts
@@ -13,6 +13,8 @@ import {
   setBootstrapMaxTime,
   setMountMaxTime,
   setUnmountMaxTime,
+  configureLogger,
+  ILogger
 } from "single-spa";
 import { expectError, expectType } from "tsd";
 
@@ -116,3 +118,18 @@ setMountMaxTime(100, true, 50);
 setUnmountMaxTime(100);
 setUnmountMaxTime(100, true);
 setUnmountMaxTime(100, true, 50);
+
+configureLogger(null);
+configureLogger(console);
+
+const customLogger: ILogger = {
+  debug(...params: any[]) { },
+  info(...params: any[]) { },
+  warn(...params: any[]) { },
+  error(...params: any[]) { },
+};
+
+configureLogger(customLogger);
+expectError<void>(
+  configureLogger(true)
+);


### PR DESCRIPTION
# Motivation

I personally would like to remove minified error message 1 (see #1161), and others have expressed their desire to completely suppress logging.

With this solution, both are possible.

## How It Works

A new utility module named `logging` has been added to the `src/utils` folder that exports 2 objects:

1. The `setLogger()` function that controls the destination of all log entries.
2. The proxy `logger` object, whose methods write to the log destination set by `setLogger()`.

By default, the log destination is the console.  Users can, at any point in their application's lifecycle, call `setLogger()` to control which log entries make it to the browser's console.

### setLogger()

This function takes 1 argument that can be `false`, `true` or a custom destination log object.

The value `false` internally sets a log destination that discards all messages; the value `true` routes all messages to the console.  The third option allows the caller to take complete control over what to do with the logged messages.

## For Maintainers and Contributors

**Never** do `console.debug()`, `console.info()`, `console.warn()` or `console.error()` ever again.  **Always** replace `console` with `logger`.  Logger is imported:

```javascript
import { logger } from 'path/to/src/utils/logging.js';
```