### PR TITLE
Support calling parcel lifecycles consecutively without waiting

### DIFF
--- a/.changeset/rotten-eggs-jump.md
+++ b/.changeset/rotten-eggs-jump.md
@@ -1,0 +1,5 @@
+---
+"single-spa": patch
+---
+
+Support calling parcel lifecycle methods consecutively without waiting for completion

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,12 +230,20 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.9':
@@ -261,6 +269,11 @@ packages:
 
   '@babel/parser@7.26.9':
     resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.3':
+    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -771,6 +784,10 @@ packages:
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
+
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
@@ -1204,11 +1221,11 @@ packages:
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
   '@types/babel__generator@7.6.2':
     resolution: {integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==}
-
-  '@types/babel__generator@7.6.8':
-    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
 
   '@types/babel__template@7.4.0':
     resolution: {integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==}
@@ -1219,8 +1236,8 @@ packages:
   '@types/babel__traverse@7.14.0':
     resolution: {integrity: sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==}
 
-  '@types/babel__traverse@7.20.6':
-    resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1478,8 +1495,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001702:
-    resolution: {integrity: sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==}
+  caniuse-lite@1.0.30001735:
+    resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -3214,9 +3231,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1':
+    optional: true
+
   '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    optional: true
 
   '@babel/helper-validator-option@7.25.9': {}
 
@@ -3247,6 +3270,11 @@ snapshots:
   '@babel/parser@7.26.9':
     dependencies:
       '@babel/types': 7.26.9
+
+  '@babel/parser@7.28.3':
+    dependencies:
+      '@babel/types': 7.28.2
+    optional: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.26.9)':
     dependencies:
@@ -3872,6 +3900,12 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@babel/types@7.28.2':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+    optional: true
+
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@changesets/apply-release-plan@7.0.10':
@@ -4475,21 +4509,21 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.26.9
-      '@babel/types': 7.26.9
-      '@types/babel__generator': 7.6.8
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
+      '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.6
+      '@types/babel__traverse': 7.28.0
+    optional: true
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.2
     optional: true
 
   '@types/babel__generator@7.6.2':
     dependencies:
       '@babel/types': 7.26.9
-
-  '@types/babel__generator@7.6.8':
-    dependencies:
-      '@babel/types': 7.26.9
-    optional: true
 
   '@types/babel__template@7.4.0':
     dependencies:
@@ -4498,17 +4532,17 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
     optional: true
 
   '@types/babel__traverse@7.14.0':
     dependencies:
       '@babel/types': 7.26.9
 
-  '@types/babel__traverse@7.20.6':
+  '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.26.9
+      '@babel/types': 7.28.2
     optional: true
 
   '@types/estree@1.0.6': {}
@@ -4793,7 +4827,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001702
+      caniuse-lite: 1.0.30001735
       electron-to-chromium: 1.5.112
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.4)
@@ -4817,7 +4851,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001702: {}
+  caniuse-lite@1.0.30001735: {}
 
   chalk@2.4.2:
     dependencies:

--- a/spec/parcels/mount-root-parcel.spec.ts
+++ b/spec/parcels/mount-root-parcel.spec.ts
@@ -172,15 +172,64 @@ describe(`root parcels`, () => {
       .then(
         () =>
           new Promise((resolve, reject) => {
+            console.log("mount promise");
             setTimeout(resolve, 20);
           }),
       )
       .then(parcel.unmount)
       .then(() => {
+        console.log("unmounted");
         expect(parcel.getStatus()).toBe(
           singleSpa.AppOrParcelStatus.NOT_MOUNTED,
         );
       });
+  });
+
+  it(`allows for calling update before mount promise has finished`, async () => {
+    const parcelConfig = createParcelConfig({ withUpdate: true });
+
+    const parcel = singleSpa.mountRootParcel(parcelConfig, {
+      domElement: document.createElement("div"),
+    });
+
+    expect(parcel.getStatus()).toBe(
+      singleSpa.AppOrParcelStatus.NOT_INITIALIZED,
+    );
+    await parcel.initPromise;
+
+    expect(parcel.getStatus()).toBe(singleSpa.AppOrParcelStatus.MOUNTING);
+    const updatePromise = parcel.update({ newProp: 1 });
+    await parcel.mountPromise;
+
+    expect(parcel.getStatus()).toBe(singleSpa.AppOrParcelStatus.UPDATING);
+
+    await updatePromise;
+    expect(parcel.getStatus()).toBe(singleSpa.AppOrParcelStatus.MOUNTED);
+  });
+
+  it(`allows for calling update multiple times consecutively`, async () => {
+    const parcelConfig = createParcelConfig({ withUpdate: true });
+
+    const parcel = singleSpa.mountRootParcel(parcelConfig, {
+      domElement: document.createElement("div"),
+    });
+
+    expect(parcel.getStatus()).toBe(
+      singleSpa.AppOrParcelStatus.NOT_INITIALIZED,
+    );
+    await parcel.initPromise;
+
+    expect(parcel.getStatus()).toBe(singleSpa.AppOrParcelStatus.MOUNTING);
+    const updatePromise = parcel.update({ newProp: 1 });
+    const updatePromise2 = parcel.update({ newProp: 2 });
+
+    await updatePromise;
+    expect(parcelConfig.updateCalls).toEqual(1);
+    expect(parcelConfig.updateProps.newProp).toEqual(1);
+
+    await updatePromise2;
+    expect(parcelConfig.updateCalls).toEqual(2);
+    expect(parcelConfig.updateProps.newProp).toEqual(2);
   });
 });
 
@@ -209,6 +258,7 @@ function createParcelConfig(opts = {}) {
     parcelConfig.updateCalls = 0;
     parcelConfig.update = function (props) {
       parcelConfig.updateCalls++;
+      parcelConfig.updateProps = props;
       return Promise.resolve();
     };
   }

--- a/spec/parcels/mount-root-parcel.spec.ts
+++ b/spec/parcels/mount-root-parcel.spec.ts
@@ -172,13 +172,11 @@ describe(`root parcels`, () => {
       .then(
         () =>
           new Promise((resolve, reject) => {
-            console.log("mount promise");
             setTimeout(resolve, 20);
           }),
       )
       .then(parcel.unmount)
       .then(() => {
-        console.log("unmounted");
         expect(parcel.getStatus()).toBe(
           singleSpa.AppOrParcelStatus.NOT_MOUNTED,
         );

--- a/src/lifecycles/lifecycle.helpers.ts
+++ b/src/lifecycles/lifecycle.helpers.ts
@@ -145,6 +145,7 @@ export interface InternalParcel {
   customProps: CustomProps;
   parentName: string;
   unmountThisParcel(): Promise<AppOrParcel>;
+  currentTask: Promise<void>;
   timeouts: AppOrParcelTimeouts;
 }
 

--- a/src/lifecycles/lifecycle.helpers.ts
+++ b/src/lifecycles/lifecycle.helpers.ts
@@ -145,7 +145,7 @@ export interface InternalParcel {
   customProps: CustomProps;
   parentName: string;
   unmountThisParcel(): Promise<AppOrParcel>;
-  currentTask: Promise<void>;
+  currentTask: Promise<LoadedAppOrParcel>;
   timeouts: AppOrParcelTimeouts;
 }
 

--- a/src/parcels/mount-parcel.ts
+++ b/src/parcels/mount-parcel.ts
@@ -96,38 +96,39 @@ export function mountParcel(
       : AppOrParcelStatus.NOT_INITIALIZED,
     customProps,
     parentName: toName(owningAppOrParcel),
+    currentTask: undefined,
     unmountThisParcel() {
-      return mountPromise
-        .then(() => {
-          if (parcel.status !== AppOrParcelStatus.MOUNTED) {
-            throw Error(
-              formatErrorMessage(
-                6,
-                __DEV__ &&
-                  `Cannot unmount parcel '${name}' -- it is in a ${parcel.status} status`,
-                name,
-                parcel.status,
-              ),
-            );
-          }
-          return toUnmountPromise(parcel as InternalParcel, true);
-        })
-        .then((value) => {
-          if (parcel.parentName) {
-            delete owningAppOrParcel.parcels[parcel.id];
-          }
+      return parcel.currentTask.then(() => {
+        if (parcel.status !== AppOrParcelStatus.MOUNTED) {
+          throw Error(
+            formatErrorMessage(
+              6,
+              __DEV__ &&
+                `Cannot unmount parcel '${name}' -- it is in a ${parcel.status} status`,
+              name,
+              parcel.status,
+            ),
+          );
+        }
 
-          return value;
-        })
-        .then((value) => {
-          resolveUnmount(value);
-          return value;
-        })
-        .catch((err) => {
-          parcel.status = AppOrParcelStatus.SKIP_BECAUSE_BROKEN;
-          rejectUnmount(err);
-          throw err;
-        });
+        return toUnmountPromise(parcel as InternalParcel, true)
+          .then((value) => {
+            if (parcel.parentName) {
+              delete owningAppOrParcel.parcels[parcel.id];
+            }
+
+            return value;
+          })
+          .then((value) => {
+            resolveUnmount(value);
+            return value;
+          })
+          .catch((err) => {
+            parcel.status = AppOrParcelStatus.SKIP_BECAUSE_BROKEN;
+            rejectUnmount(err);
+            throw err;
+          });
+      });
     },
   };
 
@@ -232,9 +233,11 @@ export function mountParcel(
   const initPromise = loadPromise.then(() =>
     toInitPromise(parcel as InternalParcel, true),
   );
-  const mountPromise = initPromise.then(() =>
-    toMountPromise(parcel as InternalParcel, true),
+
+  const mountPromise = initPromise.then(
+    () => (parcel.currentTask = toMountPromise(parcel as InternalParcel, true)),
   );
+  parcel.currentTask = mountPromise;
 
   let resolveUnmount, rejectUnmount;
 
@@ -283,11 +286,13 @@ export function mountParcel(
     (config) => {
       if (config.update) {
         externalRepresentation.update = function (customProps) {
-          parcel.customProps = customProps;
+          return (parcel.currentTask = parcel.currentTask.then(() => {
+            parcel.customProps = customProps;
 
-          return promiseWithoutReturnValue(
-            toUpdatePromise(parcel as InternalParcel),
-          );
+            return promiseWithoutReturnValue(
+              toUpdatePromise(parcel as InternalParcel),
+            );
+          }));
         };
       }
     },


### PR DESCRIPTION
This will simplify the single-spa-react implementation a lot, since react effects are synchronous whereas single-spa lifecycle methods are asynchronous. Probably the single-spa-vue and single-spa-angular implementations will also benefit from it, too.