### PR TITLE
fix: convert AppProps to interface and add proper type for singleSpa

### DIFF
--- a/typings/single-spa.d.ts
+++ b/typings/single-spa.d.ts
@@ -9,14 +9,14 @@ declare module "single-spa" {
     location: Location
   ) => ExtraProps;
 
-  export type AppProps = {
+  export interface AppProps {
     name: string;
-    singleSpa: any;
+    singleSpa: typeof import("single-spa");
     mountParcel(
       parcelConfig: ParcelConfig,
       customProps: ParcelProps & CustomProps
     ): Parcel;
-  };
+  }
 
   export type ParcelConfig<ExtraProps = CustomProps> =
     | ParcelConfigObject<ExtraProps>


### PR DESCRIPTION
- Convert from `type` to `interface` so consumers can do `Module Augmentation` and `Interface merging`
- Remove `any` from `singleSpa` property and add proper types


## Demo

### Direct imports
https://github.com/user-attachments/assets/eef79ffb-75e6-4503-bfda-324eefd4a0ba

### React single-spa: 

https://github.com/user-attachments/assets/662791af-4c99-4f7a-ac05-6892d434bcfb


 