### PR TITLE
Replace jQuery any types with an exported SingleSpaJQuery interface

### DIFF
--- a/.changelog/01.txt
+++ b/.changelog/01.txt
@@ -1,0 +1,2 @@
+feature
+Replace jQuery any types with an exported SingleSpaJQuery interface

--- a/src/jquery-support.ts
+++ b/src/jquery-support.ts
@@ -1,8 +1,18 @@
 import { routingEventsListeningTo } from "./navigation/navigation-events";
 
+export interface SingleSpaJQuery {
+  fn: {
+    jquery?: string;
+    on: Function;
+    off: Function;
+  };
+}
+
 let hasInitialized: boolean = false;
 
-export function ensureJQuerySupport(jQuery: any = window.jQuery): void {
+export function ensureJQuerySupport(
+  jQuery: SingleSpaJQuery | undefined = window.jQuery,
+): void {
   if (!jQuery && window?.$?.fn?.jquery) {
     jQuery = window.$;
   }
@@ -65,7 +75,7 @@ function captureRoutingEvents(
 
 declare global {
   interface Window {
-    jQuery?: any;
-    $?: any;
+    jQuery?: SingleSpaJQuery;
+    $?: SingleSpaJQuery;
   }
 }

--- a/src/single-spa.ts
+++ b/src/single-spa.ts
@@ -1,6 +1,6 @@
 export { start } from "./start";
 export type { StartOpts } from "./start";
-export { ensureJQuerySupport } from "./jquery-support";
+export { ensureJQuerySupport, type SingleSpaJQuery } from "./jquery-support";
 export {
   setInitMaxTime,
   setMountMaxTime,


### PR DESCRIPTION
## My intent

We know what happend RIP. 

I'd like to help move 7.0 toward a stable release, I think we are very close, and I want to do it the way this repo already works and how jolyn did it : I'll mirror how the TS migration itself was landed (folder-by-folder in #1187–#1213) and how the recent type PRs have gone.

@arturovt hi !! do you have permission to publish ? 

## What

Replaces the `any`-typed jQuery surface with a minimal, exported `SingleSpaJQuery`
interface, covering only the members single-spa actually touches (`fn.jquery`,
`fn.on`, `fn.off`).

## Why

The file-conversion phase is clearly complete — but a few `any`s still leak into the published
`single-spa.d.ts`. This removes one of them from the public surface, continuing
the type-refinement direction of the recent betas (#1294, #1300, #1340, #1341).

## Verification

- `pnpm run build` passes (type-checks via `noEmitOnError`); `single-spa.d.ts`
  no longer contains `any` on the jQuery surface
- `pnpm test` — all suites green (276 passed / 2 skipped)
- `pnpm run check-format` clean
